### PR TITLE
feat: replace cache TTL system with timestamped state attributes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ uv sync
 
 - **Comprehensive Tests**: over 500 tests covering over 80% of the source code
 - **Connection Pooling**: Efficient connection reuse
-- **State Caching**: Reduces network traffic
+- **Stores State**: Reduces network traffic
 
 ### Developer Friendly
 


### PR DESCRIPTION
The actual code changes are in commit c1f2d4076bb1913ddbb88dfbff09e4c652e595e1 but that PR used the wrong conventional commit prefix. This one should trigger a minor version bump and release.