### PR TITLE
refactor!: simplify state caching and remove TTL system

### DIFF
--- a/docs/api/devices.md
+++ b/docs/api/devices.md
@@ -160,10 +160,9 @@ from lifx import find_lights, Colors
 async def main():
     async with find_lights() as lights:
         for light in lights:
-            if light.has_extended_multizone:
-                await light.get_extended_color_zones()
-            elif light.has_multizone:
-                await light.get_color_zones()
+            # Get all zones - automatically uses best method
+            colors = await light.get_all_color_zones()
+            print(f"Device has {len(colors)} zones")
 
 ```
 

--- a/docs/architecture/effects-architecture.md
+++ b/docs/architecture/effects-architecture.md
@@ -333,18 +333,9 @@ For `MultiZoneLight` devices, zone colors are captured:
 
 ```python
 if isinstance(light, MultiZoneLight):
-    zone_count = await light.get_zone_count()
-
-    # Try extended multizone first (more efficient)
-    if light.capabilities.has_extended_multizone:
-        zone_colors = await light.get_extended_color_zones(
-            start=0, end=zone_count - 1
-        )
-    else:
-        # Fall back to standard multizone
-        zone_colors = await light.get_color_zones(
-            start=0, end=zone_count - 1
-        )
+    # Get all zones using the convenience method
+    # Automatically uses the best method based on capabilities
+    zone_colors = await light.get_all_color_zones()
 ```
 
 **Extended Multizone:**

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -187,27 +187,21 @@ Yes! Key performance features:
 
 ### How is state stored?
 
-Device properties return `(value, timestamp)` tuples with the timestamp reflecting
-when the value was last retrieved from the device. This gives you explicit
-control over data freshness:
+Selected device properties cache semi-static values that were last retrieved from the device.
+Properties return `None` if no value has been fetched yet:
 
 ```python
-import time
-
-# Check current stored state
-state = light.color
-if state:
-    color, timestamp = state
-    age = time.time() - timestamp
-    if age < 5.0:  # Use stored value if less than 5 seconds old
-        # Use state color
-    else:
-        # Data is stale, fetch fresh
-        color, _, _ = await light.get_color()
+# Check cached semi-static state (label, version, firmware, etc.)
+label = light.label
+if label:
+    # Use cached label value
+    print(f"Cached label: {label}")
 else:
-    # Ignore state, fetch from device
-    color, _, _ = await light.get_color()
+    # No cached value, fetch from device
+    label = await light.get_label()
 ```
+
+**Note**: Volatile state (power, color, hev_cycle, zones, tile_colors) is **not** cached and must always be fetched using `get_*()` methods.
 
 To always get fresh data:
 

--- a/docs/user-guide/advanced-usage.md
+++ b/docs/user-guide/advanced-usage.md
@@ -14,33 +14,27 @@ This guide covers advanced lifx patterns and techniques for building robust LIFX
 
 ## Storing State
 
-Device properties return stored state as `(value, timestamp)` tuples, giving you explicit control over data freshness.
+Device properties return cached values that were last retrieved from the device.
 
-lifx-async tries to automatically populate initial state values when a device is used as an async context manager.
-
-Non-state related properties including `version`, `model`, `min_kelvin`, and `max_kelvin` do not return a timestamp.
-
+lifx-async automatically populates initial state values when a device is used as an async context manager.
 
 ### Understanding Stored State
 
-All device state properties return timestamped tuples:
+All device state properties return cached values or `None` if not yet fetched:
 
 ```python
 from lifx import Light
-import time
 
 async def check_stored_state():
     async with await Light.from_ip("192.168.1.100") as light:
-        # Property returns tuple with (value, timestamp)
-        result = light.label
-        if result:
-            label_text, timestamp = result
-            age = time.time() - timestamp
-            print(f"Label: {label_text} (stored {age:.1f}s ago)")
+        # Property returns cached value or None
+        label = light.label
+        if label:
+            print(f"Cached label: {label}")
         else:
-            print("No stored label - fetching from device")
-            label_text = await light.get_label()
-            print(f"Label: {label_text}")
+            print("No cached label - fetching from device")
+            label = await light.get_label()
+            print(f"Label: {label}")
 ```
 
 ### Fetching Fresh Data
@@ -57,38 +51,30 @@ async def always_fresh():
         # Get other device info
         version = await light.get_version()
 
-        # Properties also get updated with new timestamp
-        stored_color = light.color  # Now has fresh data
-        stored_label = light.label  # Also updated from get_color()
+        # Some properties cache semi-static data
+        cached_label = light.label  # Updated from get_color()
 ```
 
-### Checking Data Freshness
+### Working with Cached Data
 
-Determine if stored data is still relevant:
+Use cached values when available for semi-static data, always fetch volatile state:
 
 ```python
-import time
-
-async def use_fresh_or_stored():
+async def use_cached_or_fetch():
     async with await Light.from_ip("192.168.1.100") as light:
-        MAX_AGE = 5.0  # Maximum age in seconds
-
-        # Check if we have stored color
-        stored = light.color
-        if stored:
-            color, timestamp = stored
-            age = time.time() - timestamp
-
-            if age < MAX_AGE:
-                print(f"Using stored color (age: {age:.1f}s)")
-            else:
-                print("Stored color too old, fetching fresh color")
-                # get_color() returns (color, power, label)
-                color, _, _ = await light.get_color()
+        # Check if we have cached label (semi-static)
+        label = light.label
+        if label:
+            print(f"Using cached label: {label}")
         else:
-            print("No stored color, fetching from device")
-            # get_color() returns (color, power, label)
-            color, _, _ = await light.get_color()
+            print("No cached label, fetching from device")
+            label = await light.get_label()
+            print(f"Fetched label: {label}")
+
+        # For volatile state (power, color), always fetch fresh data
+        # get_color() will only cache the label
+        color, power, label = await light.get_color()
+        print(f"Current state of {light.label} - Power: {power}, Color: {color}")
 ```
 
 ### Available Properties
@@ -96,7 +82,6 @@ async def use_fresh_or_stored():
 #### Device Properties
 
 - `Device.label` - Device name/label
-- `Device.power` - Power state (on/off)
 - `Device.version` - Vendor ID and Product ID
 - `Device.host_firmware` - Major and minor host firmware version and build number
 - `Device.wifi_firmware` - Major and minor wifi firmware version and build number
@@ -109,8 +94,6 @@ async def use_fresh_or_stored():
 
 #### Light properties
 
-- `Light.color` - Current color
-
 ##### Non-State Properties
 
 - `Light.min_kelvin` - Lowest supported kelvin value
@@ -122,25 +105,24 @@ async def use_fresh_or_stored():
 
 #### HevLight properties:
 
-- `HevLight.hev_cycle` - HEV cycle state
 - `HevLight.hev_config` - HEV configuration
 - `HevLight.hev_result` - Last HEV result
 
 #### MultiZoneLight properties:
 
 - `MultiZoneLight.zone_count` - Number of zones
-- `MultiZoneLight.zone_effect` - Either MOVE or OFF
-- `MultiZoneLight.zones` - List of zone colors
+- `MultiZoneLight.multizone_effect` - Either MOVE or OFF
 
 #### TileDevice properties:
 
 - `TileDevice.tile_count` - Number of tiles on the chain
 - `TileDevice.tile_chain` - Details of each tile on the chain
 - `TileDevice.tile_effect` - Either MORPH, FLAME, SKY or OFF
-- `TileDevice.tile_colors` - Dictionary of colors, width, and height indexed by tile
 
 
-All state properties return `None` if no data has been stored yet, or `(value, timestamp)` if data is available.
+**Note**: Volatile state properties (power, color, hev_cycle, zones, tile_colors) have been removed. Always use `get_*()` methods to fetch these values from devices as they change too frequently to benefit from caching.
+
+All cached properties return `None` if no data has been cached yet, or the cached value if available.
 
 
 ## Connection Management

--- a/examples/01_simple_discovery.py
+++ b/examples/01_simple_discovery.py
@@ -40,17 +40,17 @@ async def main():
 
             async with light:
                 print(f"  Product: {light.model}")
+                color, power, label = await light.get_color()
                 if light.label is not None:
-                    print(f"  Label: {light.label[0]}")
-                if light.power is not None:
-                    print(f"  Power: {'ON' if light.power[0] else 'OFF'}")
+                    print(f"  Label: {light.label}")
                 if light.host_firmware is not None:
-                    firmware = light.host_firmware[0]
+                    firmware = light.host_firmware
                     print(
                         f"  Firmware: {firmware.version_major}.{firmware.version_minor}"
                     )
-                if light.color is not None:
-                    print(f"  Color: {light.color[0].as_dict()}")
+
+                print(f"  Power: {'ON' if power else 'OFF'}")
+                print(f"  Color: {color.as_dict()}")
 
             print()
 

--- a/src/lifx/devices/infrared.py
+++ b/src/lifx/devices/infrared.py
@@ -41,7 +41,7 @@ class InfraredLight(Light):
         """Initialize InfraredLight with additional state attributes."""
         super().__init__(*args, **kwargs)
         # Infrared-specific state storage
-        self._infrared: tuple[float, float] | None = None
+        self._infrared: float | None = None
 
     async def _setup(self) -> None:
         """Populate Infrared light capabilities, state and metadata."""
@@ -72,10 +72,8 @@ class InfraredLight(Light):
         # Convert from uint16 (0-65535) to float (0.0-1.0)
         brightness = state.brightness / 65535.0
 
-        # Store state with timestamp
-        import time
-
-        self._infrared = (brightness, time.time())
+        # Store cached state
+        self._infrared = brightness
 
         _LOGGER.debug(
             {
@@ -121,10 +119,8 @@ class InfraredLight(Light):
             packets.Light.SetInfrared(brightness=brightness_u16),
         )
 
-        # Update state with timestamp
-        import time
-
-        self._infrared = (brightness, time.time())
+        # Update cached state
+        self._infrared = brightness
         _LOGGER.debug(
             {
                 "class": "Device",
@@ -135,11 +131,11 @@ class InfraredLight(Light):
         )
 
     @property
-    def infrared(self) -> tuple[float, float] | None:
-        """Get stored infrared brightness with timestamp if available.
+    def infrared(self) -> float | None:
+        """Get cached infrared brightness if available.
 
         Returns:
-            Tuple of (brightness, timestamp) or None if never fetched.
+            Brightness (0.0-1.0) or None if never fetched.
             Use get_infrared() to fetch from device.
         """
         return self._infrared

--- a/src/lifx/devices/light.py
+++ b/src/lifx/devices/light.py
@@ -50,8 +50,6 @@ class Light(Device):
     def __init__(self, *args, **kwargs) -> None:
         """Initialize Light with additional state attributes."""
         super().__init__(*args, **kwargs)
-        # Light-specific state storage
-        self._color: tuple[HSBK, float] | None = None
 
     async def _setup(self) -> None:
         """Populate light capabilities, state and metadata."""
@@ -90,13 +88,8 @@ class Light(Device):
         power = state.power > 0
         label = state.label
 
-        # Store color and other fields from StateColor response with timestamps
-        import time
-
-        timestamp = time.time()
-        self._color = (color, timestamp)
-        self._label = (label, timestamp)  # Already decoded to string
-        self._power = (power, timestamp)
+        # Store label from StateColor response
+        self._label = label  # Already decoded to string
 
         _LOGGER.debug(
             {
@@ -154,10 +147,6 @@ class Light(Device):
             ),
         )
 
-        # Update state with timestamp
-        import time
-
-        self._color = (color, time.time())
         _LOGGER.debug(
             {
                 "class": "Device",
@@ -367,10 +356,6 @@ class Light(Device):
         # Power level is uint16 (0 or 65535)
         is_on = state.level > 0
 
-        import time
-
-        self._power = (is_on, time.time())
-
         _LOGGER.debug(
             {
                 "class": "Device",
@@ -416,10 +401,6 @@ class Light(Device):
             packets.Light.SetPower(level=level, duration=duration_ms),
         )
 
-        # Update state with timestamp
-        import time
-
-        self._power = (on, time.time())
         _LOGGER.debug(
             {
                 "class": "Device",
@@ -706,17 +687,7 @@ class Light(Device):
             transient=True,
         )
 
-    # Stored value properties
-    @property
-    def color(self) -> tuple[HSBK, float] | None:
-        """Get stored light color with timestamp if available.
-
-        Returns:
-            Tuple of (color, timestamp) or None if never fetched.
-            Use get_color() to fetch from device.
-        """
-        return self._color
-
+    # Cached value properties
     @property
     def min_kelvin(self) -> int | None:
         """Get the minimum supported kelvin value if available.

--- a/src/lifx/effects/base.py
+++ b/src/lifx/effects/base.py
@@ -220,11 +220,8 @@ class LIFXEffect(ABC):
             ```
         """
         try:
-            if light.color:
-                current_color, _ = light.color
-            else:
-                # Fetch current color from device
-                current_color, _, _ = await light.get_color()
+            # Fetch current color from device
+            current_color, _, _ = await light.get_color()
 
             # Safety check: boost brightness if too low
             if current_color.brightness < min_brightness:

--- a/src/lifx/network/discovery.py
+++ b/src/lifx/network/discovery.py
@@ -503,7 +503,7 @@ async def discover_device_by_label(
             async with device:
                 # Match label (case-insensitive)
                 if device.label is not None:
-                    if device.label[0].lower() == label.lower():
+                    if device.label.lower() == label.lower():
                         return discovered_device
 
         except (LifxError, TimeoutError):

--- a/tests/test_devices/test_base.py
+++ b/tests/test_devices/test_base.py
@@ -57,25 +57,20 @@ class TestDevice:
         label = await device.get_label()
 
         assert label == "Living Room Light"
-        # Verify it was stored with timestamp
+        # Verify it was stored in cache
         stored = device.label
         assert stored is not None
-        stored_label, timestamp = stored
-        assert stored_label == "Living Room Light"
-        assert isinstance(timestamp, float)
+        assert stored == "Living Room Light"
 
-    async def test_label_property_with_timestamp(self, device: Device) -> None:
-        """Test label property returns tuple with timestamp."""
-        # Set stored label with timestamp
-        test_time = time.time()
-        device._label = ("Stored Label", test_time)
+    async def test_label_property_cached(self, device: Device) -> None:
+        """Test label property returns cached value."""
+        # Set stored label
+        device._label = "Stored Label"
 
         # Access property
         stored = device.label
         assert stored is not None
-        label_text, timestamp = stored
-        assert label_text == "Stored Label"
-        assert timestamp == test_time
+        assert stored == "Stored Label"
 
     async def test_set_label(self, device: Device) -> None:
         """Test setting device label."""
@@ -91,12 +86,10 @@ class TestDevice:
         packet = call_args[0][0]
         assert packet.label.startswith(b"New Label")
 
-        # Verify store was updated with timestamp
+        # Verify store was updated in cache
         stored = device.label
         assert stored is not None
-        stored_label, timestamp = stored
-        assert stored_label == "New Label"
-        assert isinstance(timestamp, float)
+        assert stored == "New Label"
 
     async def test_set_label_too_long(self, device: Device) -> None:
         """Test setting label that's too long."""
@@ -219,10 +212,6 @@ class TestDevice:
         """Test that label property is None when not yet fetched."""
         assert device.label is None
 
-    def test_power_property_none_when_not_fetched(self, device: Device) -> None:
-        """Test that power property is None when not yet fetched."""
-        assert device.power is None
-
     def test_version_property_none_when_not_fetched(self, device: Device) -> None:
         """Test that version property is None when not yet fetched."""
         assert device.version is None
@@ -325,9 +314,7 @@ class TestLocationAndGroupManagement:
         # Verify store was updated (location property returns location name as string)
         stored_location = device.location
         assert stored_location is not None
-        location_name, timestamp = stored_location
-        assert location_name == label
-        assert isinstance(timestamp, float)
+        assert stored_location == label
 
     async def test_set_group_generates_uuid(self, device: Device) -> None:
         """Test that set_group generates deterministic UUID from label."""
@@ -357,9 +344,7 @@ class TestLocationAndGroupManagement:
         # Verify store was updated (group property returns group name as string)
         stored_group = device.group
         assert stored_group is not None
-        group_name, timestamp = stored_group
-        assert group_name == label
-        assert isinstance(timestamp, float)
+        assert stored_group == label
 
     async def test_multiple_devices_same_location_label(self) -> None:
         """Test that multiple devices with same location label get same UUID."""
@@ -386,9 +371,7 @@ class TestLocationAndGroupManagement:
         # Both devices should have the same location name
         assert device1.location is not None
         assert device2.location is not None
-        loc1_name, ts1 = device1.location
-        loc2_name, ts2 = device2.location
-        assert loc1_name == loc2_name == label
+        assert device1.location == device2.location == label
 
     async def test_multiple_devices_same_group_label(self) -> None:
         """Test that multiple devices with same group label get same UUID."""
@@ -415,9 +398,7 @@ class TestLocationAndGroupManagement:
         # Both devices should have the same group name
         assert device1.group is not None
         assert device2.group is not None
-        grp1_name, ts1 = device1.group
-        grp2_name, ts2 = device2.group
-        assert grp1_name == grp2_name == label
+        assert device1.group == device2.group == label
 
     async def test_set_location_empty_label_fails(self, device: Device) -> None:
         """Test that empty location label raises ValueError."""
@@ -569,9 +550,7 @@ class TestLocationAndGroupManagement:
         # Verify store was updated with location name
         stored_location = device.location
         assert stored_location is not None
-        location_name, timestamp = stored_location
-        assert location_name == label
-        assert isinstance(timestamp, float)
+        assert stored_location == label
 
     async def test_set_location_creates_new_uuid_when_not_found(
         self, device: Device
@@ -668,9 +647,7 @@ class TestLocationAndGroupManagement:
         # Verify store was updated with group name
         stored_group = device.group
         assert stored_group is not None
-        group_name, timestamp = stored_group
-        assert group_name == label
-        assert isinstance(timestamp, float)
+        assert stored_group == label
 
     async def test_set_group_creates_new_uuid_when_not_found(
         self, device: Device

--- a/tests/test_devices/test_hev.py
+++ b/tests/test_devices/test_hev.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from lifx.devices.hev import HevLight
@@ -170,16 +168,9 @@ class TestHevLight:
         )
         hev_light.connection.request.return_value = mock_state
 
-        # First call should hit the device and store the value
-        state1 = await hev_light.get_hev_cycle()
+        # First call should hit the device
+        _ = await hev_light.get_hev_cycle()
         assert hev_light.connection.request.call_count == 1
-
-        # Check that value is stored as a tuple with timestamp
-        stored = hev_light.hev_cycle
-        assert stored is not None
-        stored_state, timestamp = stored
-        assert stored_state.duration_s == state1.duration_s
-        assert isinstance(timestamp, float)
 
     async def test_hev_config_caching(self, hev_light: HevLight) -> None:
         """Test HEV config caching."""
@@ -193,12 +184,10 @@ class TestHevLight:
         config1 = await hev_light.get_hev_config()
         assert hev_light.connection.request.call_count == 1
 
-        # Check that value is stored as a tuple with timestamp
+        # Check that value is stored in cache
         stored = hev_light.hev_config
         assert stored is not None
-        stored_config, timestamp = stored
-        assert stored_config.duration_s == config1.duration_s
-        assert isinstance(timestamp, float)
+        assert stored.duration_s == config1.duration_s
 
     async def test_hev_result_caching(self, hev_light: HevLight) -> None:
         """Test HEV result caching."""
@@ -211,64 +200,38 @@ class TestHevLight:
         result1 = await hev_light.get_last_hev_result()
         assert hev_light.connection.request.call_count == 1
 
-        # Check that value is stored as a tuple with timestamp
+        # Check that value is stored in cache
         stored = hev_light.hev_result
         assert stored is not None
-        stored_result, timestamp = stored
-        assert stored_result == result1
-        assert isinstance(timestamp, float)
-
-    async def test_hev_cycle_property(self, hev_light: HevLight) -> None:
-        """Test hev_cycle property returns stored value with timestamp."""
-        # Initially no stored value
-        assert hev_light.hev_cycle is None
-
-        # Set stored value with timestamp
-        state = HevCycleState(duration_s=3600, remaining_s=1800, last_power=True)
-        test_time = time.time()
-        hev_light._hev_cycle = (state, test_time)
-
-        # Property should return stored value as tuple
-        stored = hev_light.hev_cycle
-        assert stored is not None
-        stored_state, timestamp = stored
-        assert stored_state == state
-        assert stored_state.duration_s == 3600
-        assert timestamp == test_time
+        assert stored == result1
 
     async def test_hev_config_property(self, hev_light: HevLight) -> None:
-        """Test hev_config property returns stored value with timestamp."""
+        """Test hev_config property returns cached value."""
         # Initially no stored value
         assert hev_light.hev_config is None
 
-        # Set stored value with timestamp
+        # Set stored value
         config = HevConfig(indication=True, duration_s=7200)
-        test_time = time.time()
-        hev_light._hev_config = (config, test_time)
+        hev_light._hev_config = config
 
-        # Property should return stored value as tuple
+        # Property should return stored value
         stored = hev_light.hev_config
         assert stored is not None
-        stored_config, timestamp = stored
-        assert stored_config == config
-        assert stored_config.duration_s == 7200
-        assert timestamp == test_time
+        assert stored == config
+        assert stored.duration_s == 7200
 
     async def test_hev_result_property(self, hev_light: HevLight) -> None:
-        """Test hev_result property returns stored value with timestamp."""
+        """Test hev_result property returns cached value."""
         # Initially no stored value
         assert hev_light.hev_result is None
 
-        # Set stored value with timestamp
-        test_time = time.time()
-        hev_light._hev_result = (LightLastHevCycleResult.SUCCESS, test_time)
+        # Set stored value
+        hev_light._hev_result = LightLastHevCycleResult.SUCCESS
 
-        # Property should return stored value as tuple
+        # Property should return stored value
         stored = hev_light.hev_result
         assert stored is not None
-        stored_result, timestamp = stored
-        assert stored_result == LightLastHevCycleResult.SUCCESS
-        assert timestamp == test_time
+        assert stored == LightLastHevCycleResult.SUCCESS
 
     async def test_set_hev_config_updates_store(self, hev_light: HevLight) -> None:
         """Test that setting HEV config updates the store."""
@@ -276,25 +239,8 @@ class TestHevLight:
 
         await hev_light.set_hev_config(indication=False, duration_seconds=5400)
 
-        # Check store was updated as tuple with timestamp
+        # Check store was updated in cache
         stored = hev_light.hev_config
         assert stored is not None
-        config, timestamp = stored
-        assert config.indication is False
-        assert config.duration_s == 5400
-        assert isinstance(timestamp, float)
-
-    async def test_set_hev_cycle_invalidates_store(self, hev_light: HevLight) -> None:
-        """Test that setting HEV cycle invalidates the cycle state store."""
-        hev_light.connection.request.return_value = True
-
-        # Set initial store
-        state = HevCycleState(duration_s=3600, remaining_s=1800, last_power=True)
-        hev_light._hev_cycle = (state, time.time())
-        assert hev_light.hev_cycle is not None
-
-        # Set HEV cycle
-        await hev_light.set_hev_cycle(enable=True, duration_seconds=7200)
-
-        # Store should be invalidated
-        assert hev_light.hev_cycle is None
+        assert stored.indication is False
+        assert stored.duration_s == 5400

--- a/tests/test_devices/test_infrared.py
+++ b/tests/test_devices/test_infrared.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from lifx.devices.infrared import InfraredLight
@@ -115,28 +113,23 @@ class TestInfraredLight:
         brightness1 = await infrared_light.get_infrared()
         assert infrared_light.connection.request.call_count == 1
 
-        # Check that value is stored as a tuple with timestamp
+        # Check that value is stored in cache
         stored = infrared_light.infrared
         assert stored is not None
-        stored_brightness, timestamp = stored
-        assert stored_brightness == pytest.approx(brightness1, abs=0.01)
-        assert isinstance(timestamp, float)
+        assert stored == pytest.approx(brightness1, abs=0.01)
 
     async def test_infrared_property(self, infrared_light: InfraredLight) -> None:
-        """Test infrared property returns stored value with timestamp."""
+        """Test infrared property returns cached value."""
         # Initially no stored value
         assert infrared_light.infrared is None
 
-        # Set stored value with timestamp
-        test_time = time.time()
-        infrared_light._infrared = (0.6, test_time)
+        # Set stored value
+        infrared_light._infrared = 0.6
 
-        # Property should return stored value as tuple
+        # Property should return stored value
         stored = infrared_light.infrared
         assert stored is not None
-        brightness, timestamp = stored
-        assert brightness == pytest.approx(0.6, abs=0.01)
-        assert timestamp == test_time
+        assert stored == pytest.approx(0.6, abs=0.01)
 
     async def test_set_infrared_updates_store(
         self, infrared_light: InfraredLight
@@ -146,9 +139,7 @@ class TestInfraredLight:
 
         await infrared_light.set_infrared(0.8)
 
-        # Check store was updated as tuple with timestamp
+        # Check store was updated in cache
         stored = infrared_light.infrared
         assert stored is not None
-        brightness, timestamp = stored
-        assert brightness == pytest.approx(0.8, abs=0.01)
-        assert isinstance(timestamp, float)
+        assert stored == pytest.approx(0.8, abs=0.01)

--- a/tests/test_devices/test_light.py
+++ b/tests/test_devices/test_light.py
@@ -49,14 +49,6 @@ class TestLight:
         assert power is True
         assert label == "Test Light"
 
-        # Verify it was stored with timestamp
-        stored = light.color
-        assert stored is not None
-        stored_color, timestamp = stored
-        assert isinstance(stored_color, HSBK)
-        assert stored_color.hue == pytest.approx(180, abs=1)
-        assert isinstance(timestamp, float)
-
     async def test_set_color(self, light: Light) -> None:
         """Test setting light color."""
         # Mock SET operation returns True

--- a/tests/test_effects/test_base.py
+++ b/tests/test_effects/test_base.py
@@ -28,7 +28,6 @@ def mock_light():
     """Create a mock light device."""
     light = MagicMock()
     light.serial = "d073d5123456"
-    light.color = None
     return light
 
 
@@ -59,26 +58,11 @@ def test_effect_repr(effect):
 
 
 @pytest.mark.asyncio
-async def test_fetch_light_color_from_cached(effect, mock_light):
-    """Test fetching color from cached light.color."""
-    # Setup cached color
-    cached_color = HSBK(hue=120, saturation=1.0, brightness=0.8, kelvin=3500)
-    mock_light.color = (cached_color, 100)
-
-    # Fetch color
-    result = await effect.fetch_light_color(mock_light)
-
-    # Should use cached color
-    assert result == cached_color
-    assert not mock_light.get_color.called
-
-
-@pytest.mark.asyncio
 async def test_fetch_light_color_from_device(effect, mock_light):
-    """Test fetching color from device when not cached."""
+    """Test fetching color from device."""
     # Setup device color
     device_color = HSBK(hue=240, saturation=0.9, brightness=0.7, kelvin=4000)
-    mock_light.get_color = AsyncMock(return_value=(device_color, 100, 200))
+    mock_light.get_color = AsyncMock(return_value=(device_color, True, "Test Light"))
 
     # Fetch color
     result = await effect.fetch_light_color(mock_light)
@@ -91,9 +75,9 @@ async def test_fetch_light_color_from_device(effect, mock_light):
 @pytest.mark.asyncio
 async def test_fetch_light_color_brightness_boost(effect, mock_light):
     """Test brightness boost when color is too dim."""
-    # Setup dim color
+    # Setup dim color from device
     dim_color = HSBK(hue=180, saturation=1.0, brightness=0.05, kelvin=3500)
-    mock_light.color = (dim_color, 100)
+    mock_light.get_color = AsyncMock(return_value=(dim_color, True, "Test Light"))
 
     # Fetch color with default fallback
     result = await effect.fetch_light_color(mock_light)
@@ -108,9 +92,9 @@ async def test_fetch_light_color_brightness_boost(effect, mock_light):
 @pytest.mark.asyncio
 async def test_fetch_light_color_custom_fallback(effect, mock_light):
     """Test brightness boost with custom fallback brightness."""
-    # Setup dim color
+    # Setup dim color from device
     dim_color = HSBK(hue=90, saturation=0.8, brightness=0.02, kelvin=2700)
-    mock_light.color = (dim_color, 100)
+    mock_light.get_color = AsyncMock(return_value=(dim_color, True, "Test Light"))
 
     # Fetch color with custom fallback
     result = await effect.fetch_light_color(
@@ -124,9 +108,9 @@ async def test_fetch_light_color_custom_fallback(effect, mock_light):
 @pytest.mark.asyncio
 async def test_fetch_light_color_custom_min_threshold(effect, mock_light):
     """Test custom minimum brightness threshold."""
-    # Setup color just below custom threshold
+    # Setup color just below custom threshold from device
     color = HSBK(hue=45, saturation=0.7, brightness=0.15, kelvin=3000)
-    mock_light.color = (color, 100)
+    mock_light.get_color = AsyncMock(return_value=(color, True, "Test Light"))
 
     # Fetch with higher minimum threshold
     result = await effect.fetch_light_color(


### PR DESCRIPTION
Remove TTL-based state caching system in favor of simpler direct value
caching. Volatile properties (power, color, hev_cycle, zones, tile_colors)
are no longer cached and must be fetched using get_*() methods.

BREAKING CHANGES:

* Device properties now return simple values instead of (value, timestamp) tuples
  - Before: `label, timestamp = device.label`
  - After: `label = device.label`

* Removed cached properties for volatile state:
  - `Device.power` property removed - use `get_power()` instead
  - `Light.color` property removed - use `get_color()` instead
  - `HevLight.hev_cycle` property removed - use `get_hev_cycle()` instead
  - `MultiZoneLight.zones` property removed - use `get_color_zones()` or `get_all_color_zones()` instead
  - `TileDevice.tile_colors` property removed - use `get_tile_colors()` instead

* Removed `refresh` parameter from `Device.set_power()` method
  - Before: `await device.set_power(True, refresh=True)`
  - After: `await device.set_power(True)`

* `Device._setup()` no longer fetches power state during initialization

Features:

* Add default parameters (start=0, end=255) to MultiZoneLight methods:
  - `get_color_zones()` now accepts optional parameters
  - `get_extended_color_zones()` now accepts optional parameters
  - Calling without parameters returns all zones automatically

* Add `MultiZoneLight.get_all_color_zones()` convenience method:
  - Parameter-less method that always returns all zones
  - Automatically selects best protocol (extended or standard) based on capabilities
  - Simplifies common use case of fetching all zones

* Refactor `get_extended_color_zones()` for better separation of concerns:
  - Remove has_extended_multizone capability check
  - Move capability checking logic to get_all_color_zones()
  - Keep protocol methods focused on their specific protocols

Documentation:

* Update CLAUDE.md with comprehensive state caching documentation
* Add MultiZone Light Control section with usage examples
* Update docs/api/devices.md with simplified examples
* Update docs/architecture/effects-architecture.md
* Update docs/architecture/overview.md
* Update docs/faq.md
* Update docs/user-guide/advanced-usage.md
* Update examples/01_simple_discovery.py

Tests:

* Add test coverage for get_all_color_zones() with both capability types
* Add tests for default parameters in multizone methods
* Update all device tests to remove power/color property assertions
* Update tests to remove refresh parameter usage
* Update effects tests to remove cached color property usage
* Update effects/base.py to always fetch color via get_color()

All changes maintain backward compatibility for method calls, but property
access patterns have changed significantly. Applications using cached
properties will need updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
