### PR TITLE
ci: optimize test runs to eliminate redundancy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
     - main
+    tags-ignore:
+    - '**'  # Don't run on tag pushes (semantic-release)
   pull_request:
+    paths:
+    - src/**
+    - tests/**
+    - pyproject.toml
+    - uv.lock
+    - .github/workflows/ci.yml
+    - .pre-commit-config.yaml
 
 
 env:
@@ -51,6 +60,8 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Only run tests on pull requests (skip on main branch pushes since tests already passed in PR)
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +107,8 @@ jobs:
     needs:
     - quality
     - test
+    # Always run release if quality passed, even if tests were skipped
+    if: always() && needs.quality.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Reduce unnecessary CI test executions by implementing smart triggering:

- Add path filters to only run tests on PRs when relevant files change (src/, tests/, pyproject.toml, uv.lock, CI config, pre-commit config)
- Skip tests on main branch pushes since they already passed in the PR (works with all merge strategies: rebase, squash, merge)
- Exclude tag pushes to prevent tests running when semantic-release creates release tags
- Update release job condition to proceed when tests are skipped

This eliminates redundant test runs while maintaining safety:
- Tests run once per PR before merge (required by branch protection)
- Tests skip after PR lands on main (already validated)
- Tests skip on release tag creation (already validated)
- Quality checks (lint, format, type) still run on every push

Benefits:
- Reduces CI time by ~66% (tests run once instead of three times)
- Saves 12 test matrix jobs per merge (3 OS × 4 Python versions)
- Faster releases without waiting for redundant test execution
- Lower resource usage and faster feedback loops