### PR TITLE
feat: add mac_address property to Device class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,32 @@ serial_bytes = serial.value            # 6 bytes
 serial = Serial.from_protocol(protocol_bytes)
 ```
 
+### MAC Address Calculation
+
+The `mac_address` property on `Device` provides the device's MAC address, calculated from the serial
+number and host firmware version. The calculation is automatically performed when `get_host_firmware()`
+is called or when using the device as a context manager.
+
+**Calculation Logic** (based on host firmware major version):
+- **Version 2 or 4**: MAC address matches the serial
+- **Version 3**: MAC address is serial with LSB + 1 (with wraparound from 0xFF to 0x00)
+- **Unknown versions**: Defaults to serial
+
+**Format**: MAC address is returned in colon-separated lowercase hex format (e.g., `d0:73:d5:01:02:03`)
+to visually distinguish it from the serial number format.
+
+```python
+from lifx.devices import Device
+
+async with await Device.from_ip("192.168.1.100") as device:
+    # MAC address is automatically calculated during device setup
+    if device.mac_address:
+        print(f"MAC: {device.mac_address}")  # e.g., "d0:73:d5:01:02:04"
+
+    # Returns None before host_firmware is fetched
+    assert device.mac_address is not None
+```
+
 ### Color Representation
 
 The `HSBK` class (in `color.py`) provides user-friendly color handling:

--- a/docs/api/devices.md
+++ b/docs/api/devices.md
@@ -81,6 +81,37 @@ The `TileDevice` class controls LIFX tile grids with 2D zone control.
       filters:
         - "!^_"
 
+## Device Properties
+
+### MAC Address
+
+The `mac_address` property provides the device's MAC address, calculated from the serial number
+and host firmware version. The calculation is performed automatically when the device is used
+as a context manager or when `get_host_firmware()` is called.
+
+**Calculation Logic** (based on host firmware major version):
+
+- **Version 2 or 4**: MAC address matches the serial number
+- **Version 3**: MAC address is the serial number with the least significant byte incremented by 1 (with wraparound from 0xFF to 0x00)
+- **Unknown versions**: Defaults to the serial number
+
+The MAC address is returned in colon-separated lowercase hexadecimal format (e.g., `d0:73:d5:01:02:03`)
+to visually distinguish it from the serial number format.
+
+```python
+from lifx import Device
+
+async def main():
+    async with await Device.from_ip("192.168.1.100") as device:
+        # MAC address is automatically calculated during setup
+        if device.mac_address:
+            print(f"Serial: {device.serial}")
+            print(f"MAC:    {device.mac_address}")
+
+        # Returns None before host_firmware is fetched
+        assert device.mac_address is not None
+```
+
 ## Examples
 
 ### Basic Light Control

--- a/tests/test_devices/test_mac_address.py
+++ b/tests/test_devices/test_mac_address.py
@@ -1,0 +1,119 @@
+"""Tests for MAC address calculation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from lifx.devices.base import Device
+from lifx.protocol import packets
+
+
+class TestMacAddress:
+    """Tests for MAC address calculation."""
+
+    async def test_mac_address_version_2(self, device: Device) -> None:
+        """Test MAC address calculation for firmware version 2."""
+        # Mock firmware version 2
+        mock_firmware = packets.Device.StateHostFirmware(
+            build=1234567890, version_major=2, version_minor=77
+        )
+        device.connection.request.return_value = mock_firmware
+
+        # Get host firmware to trigger MAC calculation
+        await device.get_host_firmware()
+
+        # For version 2, MAC should match serial (with colons)
+        # Device serial is "d073d5010203" (from fixture)
+        expected_mac = "d0:73:d5:01:02:03"
+        assert device.mac_address == expected_mac
+
+    async def test_mac_address_version_4(self, device: Device) -> None:
+        """Test MAC address calculation for firmware version 4."""
+        # Mock firmware version 4
+        mock_firmware = packets.Device.StateHostFirmware(
+            build=1234567890, version_major=4, version_minor=0
+        )
+        device.connection.request.return_value = mock_firmware
+
+        # Get host firmware to trigger MAC calculation
+        await device.get_host_firmware()
+
+        # For version 4, MAC should match serial (with colons)
+        expected_mac = "d0:73:d5:01:02:03"
+        assert device.mac_address == expected_mac
+
+    async def test_mac_address_version_3(self, device: Device) -> None:
+        """Test MAC address calculation for firmware version 3."""
+        # Mock firmware version 3
+        mock_firmware = packets.Device.StateHostFirmware(
+            build=1234567890, version_major=3, version_minor=70
+        )
+        device.connection.request.return_value = mock_firmware
+
+        # Get host firmware to trigger MAC calculation
+        await device.get_host_firmware()
+
+        # For version 3, MAC should be serial + 1 on LSB
+        # Device serial is "d073d5010203" (from fixture)
+        # LSB is 0x03, so MAC should end with 0x04
+        expected_mac = "d0:73:d5:01:02:04"
+        assert device.mac_address == expected_mac
+
+    async def test_mac_address_version_3_wraparound(self) -> None:
+        """Test MAC address calculation for firmware version 3 with LSB wraparound."""
+        # Create device with serial ending in FF
+        device_ff = Device(serial="d073d50102ff", ip="192.168.1.100")
+        device_ff.connection = MagicMock()
+        device_ff.connection.request = AsyncMock()
+
+        # Mock firmware version 3
+        mock_firmware = packets.Device.StateHostFirmware(
+            build=1234567890, version_major=3, version_minor=70
+        )
+        device_ff.connection.request.return_value = mock_firmware
+
+        # Get host firmware to trigger MAC calculation
+        await device_ff.get_host_firmware()
+
+        # For version 3 with LSB=0xff, MAC should wrap around to 0x00
+        expected_mac = "d0:73:d5:01:02:00"
+        assert device_ff.mac_address == expected_mac
+
+    async def test_mac_address_none_before_firmware_fetch(self, device: Device) -> None:
+        """Test MAC address is None before firmware is fetched."""
+        # MAC address should be None initially
+        assert device.mac_address is None
+
+    async def test_mac_address_unknown_version(self, device: Device) -> None:
+        """Test MAC address defaults to serial for unknown firmware version."""
+        # Mock firmware with unknown version (not 2, 3, or 4)
+        mock_firmware = packets.Device.StateHostFirmware(
+            build=1234567890, version_major=5, version_minor=0
+        )
+        device.connection.request.return_value = mock_firmware
+
+        # Get host firmware to trigger MAC calculation
+        await device.get_host_firmware()
+
+        # For unknown version, MAC should default to serial (with colons)
+        expected_mac = "d0:73:d5:01:02:03"
+        assert device.mac_address == expected_mac
+
+    async def test_mac_address_format(self, device: Device) -> None:
+        """Test MAC address is formatted with colons."""
+        # Mock firmware version 2
+        mock_firmware = packets.Device.StateHostFirmware(
+            build=1234567890, version_major=2, version_minor=77
+        )
+        device.connection.request.return_value = mock_firmware
+
+        # Get host firmware to trigger MAC calculation
+        await device.get_host_firmware()
+
+        # Verify format with colons
+        assert device.mac_address is not None
+        assert ":" in device.mac_address
+        # Should have 5 colons (6 octets)
+        assert device.mac_address.count(":") == 5
+        # Should be lowercase hex
+        assert device.mac_address == device.mac_address.lower()


### PR DESCRIPTION
Add a new `mac_address` property to the Device class that calculates the device's MAC address from the serial number and host firmware version.

The calculation logic depends on the host firmware major version:
- Version 2 or 4: MAC address matches the serial number
- Version 3: MAC address is serial with LSB + 1 (wraparound from FF to 00)
- Unknown versions: Defaults to serial number

The MAC address is returned in colon-separated lowercase hexadecimal format (e.g., "d0:73:d5:01:02:03") to visually distinguish it from the serial number format.

Key implementation details:
- Property is stored in private `_mac_address` attribute
- Calculation performed automatically when `get_host_firmware()` is called
- Returns `None` if host firmware hasn't been fetched yet
- Comprehensive test suite with 7 tests covering all firmware versions and edge cases (wraparound, format validation)

Documentation updates:
- Added MAC Address Calculation section to CLAUDE.md
- Added Device Properties section to docs/api/devices.md
- Included usage examples in both documentation locations