### PR TITLE
feat: remove connection pool in favor of lazy device-owned connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,9 @@ uv run mkdocs gh-deploy
 
    - `transport.py`: UDP transport using asyncio
    - `discovery.py`: Device discovery via broadcast with `DiscoveredDevice` dataclass
-   - `connection.py`: Device connection with retry logic and connection pooling
+   - `connection.py`: Device connection with retry logic and lazy opening
    - `message.py`: Message building and parsing with `MessageBuilder`
-   - Connection pooling with LRU cache and metrics tracking (`ConnectionPoolMetrics`)
+   - Lazy connection opening (auto-opens on first request)
 
 3. **Device Layer** (`src/lifx/devices/`)
 
@@ -201,7 +201,7 @@ except LifxDeviceNotFoundError:
 - **Type Safety**: Full type hints with strict Pyright validation
 - **Auto-Generation**: Protocol structures generated from YAML specification
 - **State Caching**: Device properties cache values to reduce network requests
-- **Connection Pooling**: LRU cache for connection reuse across operations
+- **Lazy Connections**: Connections open automatically on first request
 - **Async Generator Streaming**: Request/response communication via async generators
 
 ### State Caching

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,7 +19,7 @@ lifx/
 │   ├── multizone.py         # MultiZoneLight (strips/beams)
 │   └── tile.py              # TileDevice (2D pixel grids)
 ├── network/                  # Network layer
-│   ├── connection.py        # Device connections with pooling
+│   ├── connection.py        # Device connections with lazy opening
 │   ├── discovery.py         # Network device discovery
 │   ├── message.py           # Message building and parsing
 │   └── transport.py         # UDP transport
@@ -117,9 +117,9 @@ await group.set_power(True)
 await group.set_color(Colors.BLUE)
 ```
 
-### Connection Pooling
+### Connection Lifecycle
 
-Connections are automatically pooled and reused:
+Connections open lazily on first request and reuse the same socket:
 
 ```python
 # Multiple operations reuse the same connection
@@ -127,6 +127,7 @@ async with await Light.from_ip("192.168.1.100") as light:
     await light.set_color(Colors.RED)
     await light.set_brightness(0.5)
     await light.get_label()
+# Connection automatically closed on exit
 ```
 
 ### Concurrent Requests

--- a/docs/architecture/effects-architecture.md
+++ b/docs/architecture/effects-architecture.md
@@ -716,10 +716,10 @@ No special device modifications needed.
 
 ### With Network Layer
 
-Effects rely on existing connection pooling and concurrent request support:
+Effects rely on existing lazy connection and concurrent request support:
 
-- Connection pooling (LRU cache) reuses connections
-- Background response dispatcher handles concurrent requests
+- Lazy connections open on first request and are reused
+- Requests are serialized via lock to prevent response mixing
 - No effect-specific network code needed
 
 ### With Protocol Layer
@@ -743,7 +743,7 @@ Effects use existing protocol structures:
 
 - **Minimal:** Async I/O bound, not CPU bound
 - **Concurrency:** Multiple devices don't increase CPU significantly
-- **Background Tasks:** One receiver task per connection (managed by connection pool)
+- **Background Tasks:** Requests serialized per connection, concurrent across devices
 
 ### Network Traffic
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ effects, and more.
 
 ### Which devices are supported?
 
-lifx-async supports all LIFX lighting products:
+lifx-async supports all LIFX lighting products, including:
 
 - **Light**: A19, BR30, Downlight, etc.
 - **HEV**: Clean
@@ -18,8 +18,8 @@ lifx-async supports all LIFX lighting products:
 - **Multizone**: LIFX Z, Beam, Neon, String
 - **Matrix**: LIFX Tile, Candle, Ceiling, Path, Spot
 
-Button and Relay devices are not currently supported (they are out of scope for this
-lighting-focused library).
+LIFX Switches are out of scope for this lighting-focused library and are
+therefore not supported.
 
 ### Do I need cloud access?
 
@@ -53,10 +53,10 @@ Common issues:
 1. **Timeout**: Try increasing timeout: `discover(timeout=10.0)`
 1. **Router**: Some routers block broadcast packets - try direct connection
 
-**Workaround** - Connect directly by IP:
+**Workaround** - Connect directly using IP and serial:
 
 ```python
-async with await Light.from_ip("192.168.1.100") as light:
+async with await Light(serial="d073d5000000",  ip="192.168.1.100") as light:
     await light.set_color(Colors.BLUE)
 ```
 
@@ -65,15 +65,11 @@ async with await Light.from_ip("192.168.1.100") as light:
 No! Discovery finds devices automatically:
 
 ```python
-from lifx import discover, DeviceGroup
+from lifx import discover
 
-devices = []
 async for device in discover():
-    devices.append(device)
-group = DeviceGroup(devices)
+    print(f"Found {device.serial} at {device.ip}")
 
-# All devices found automatically
-await group.set_color(Colors.BLUE)
 ```
 
 If you do know the IP, you can connect directly for faster connection.
@@ -190,14 +186,15 @@ await light.breathe(Colors.BLUE, period=2.0, cycles=0)
 Yes! Key performance features:
 
 - **Async I/O**: Non-blocking operations
-- **Connection Pooling**: Reuses connections (LRU cache)
-- **Rate Limiting**: Prevents overwhelming devices (20 msg/sec)
-- **State Caching**: Reduces redundant network requests
-- **Concurrent Requests**: Multiple requests per connection
+- **Lazy Connections**: Auto-open on first request, reuse for all operations
+- **Non-volatile State Caching**: Reduces redundant network requests
+- **Concurrent Devices**: Operations on different devices run in parallel
+- **Request Serialization**: Prevents response mixing on same connection
 
 ### How is state stored?
 
-Selected device properties cache semi-static values that were last retrieved from the device.
+Selected device properties that are considered non-volatile, including product ID
+and firmware version are cached after they are fetched for the first time.
 Properties return `None` if no value has been fetched yet:
 
 ```python
@@ -222,6 +219,14 @@ color, power, label = await light.get_color()  # Returns (color, power, label)
 
 # Or fetch specific info separately
 version = await light.get_version()  # Get firmware and hardware version
+```
+
+If you use a light as an async context manager, it will automatically populate
+all of the non-volatile properties:
+
+```python
+async with Light(serial="d073d5000000",  ip="192.168.1.100") as light:
+    print(f"{light.label} is a {light.model} and is in the {light.group} group.")
 ```
 
 ### Can I control devices from multiple computers?
@@ -323,11 +328,11 @@ async with DeviceConnection(serial, ip) as conn:
     reply = await conn.request(packet)
 ```
 
-### How does connection pooling work?
+### How does connection management work?
 
-lifx-async maintains an LRU cache of connections. When you open a connection to a device, it's
-automatically pooled and reused for subsequent operations. Connections are evicted when the cache is
-full (default maximum: 100 connections).
+Each device owns its own connection that opens lazily on first request. The connection is reused for
+all subsequent operations on that device. Connections are automatically closed when you exit the
+device's context manager, or you can manually call `await device.connection.close()`.
 
 ## Still have questions?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@ A modern, type-safe, async Python library for controlling LIFX lights over the l
 
 - **📦 No Runtime Dependencies**: only Python standard libraries required
 - **🎯 Type-Safe**: Full type hints with strict Pyright validation
+- **🔌 Async Generators**: Provides `async for` usage pattern
 - **⚡ Async Context Managers**: Provides `async with` and `await` usage patterns
-- **🔌 Connection Pooling**: Efficient reuse with LRU cache
+- **🔌 Lazy Connections**: Auto-open on first request, explicit cleanup
 - **🏗️ Layered Architecture**: Protocol → Network → Device → API
 - **🔄 Protocol Generator**: generates LIFX protocol `Packets`, `Fields` and `Enum` classes from LIFX public protocol definition
 - **🌈 Comprehensive Support**: supports all LIFX smart lighting products including Color, White, Warm to White, Filament, Clean, Night Vision, Z, Beam, String, Neon, Permanent Outdoor, Tile, Candle, Ceiling, Path, Spot, and Luna.
@@ -21,21 +22,11 @@ A modern, type-safe, async Python library for controlling LIFX lights over the l
     from lifx import discover, Colors
 
     async def main():
-        # Discover all devices with automatic connection management
-        async with discover(timeout=3.0) as group:
-            if not group:
-                print("No LIFX devices found!")
-                return
-
-            # Control all devices at once
-            await group.set_power(True)
-            await group.set_color(Colors.BLUE, duration=1.0)
-            await group.set_brightness(0.5)
-
-            # Or control individual devices
-            for device in group:
-                label = await device.get_label()
-                print(f"Controlling: {label}")
+        # Discover devices asynchronously:
+        async for device in discover():
+            # Control each device as it is discovered
+            await device.set_power(True)
+            await device.set_color(Colors.BLUE, duration=1.0)
 
     asyncio.run(main())
     ```
@@ -44,13 +35,15 @@ A modern, type-safe, async Python library for controlling LIFX lights over the l
 
     ```python
     import asyncio
-    from lifx import Light, Colors
+    from lifx import Light, HSBK
 
     async def main():
-        # Connect directly without discovery
-        async with await Light.from_ip(ip="192.168.1.100") as light:
-            await light.set_color(Colors.RED)
-            await light.set_brightness(0.8, duration=2.0)
+        # Connect most efficiently without discovery using serial and IP
+        async with Light(serial="d073d5010203", ip="192.168.1.100") as light:
+            # Using Light as a context manager auto-populates non-volatile state information
+            print(f"{light.label} is a {light.model} at {light.location} in the {light.group} group.")
+
+            await light.set_color(HSBK(hue=0, saturation=1.0, brightness=0.8, kelvin=3500), duration=2.0)
 
     asyncio.run(main())
     ```
@@ -62,7 +55,7 @@ A modern, type-safe, async Python library for controlling LIFX lights over the l
     from lifx import Light, HSBK, Colors
 
     async def main():
-        async with await Light.from_ip(ip="192.168.1.100") as light:
+        async with Light(serial="d073d5010203", ip="192.168.1.100") as light:
             # Use RGB
             red = HSBK.from_rgb(255, 0, 0)
             await light.set_color(red)
@@ -104,15 +97,15 @@ uv sync
 
 ### Modern Python
 
-- **Async With**: extensive use of async context managers
+- **Async For** and **Async With**: extensive use of asynchronous generators and context managers
 - **Async/Await**: Native asyncio support for concurrent operations
 - **Type Hints**: Full type annotations for better IDE support
 - **Python 3.11+**: Modern language features and performance
 
 ### Reliable
 
-- **Comprehensive Tests**: over 500 tests covering over 80% of the source code
-- **Connection Pooling**: Efficient connection reuse
+- **Comprehensive Tests**: over 700 tests covering over 90% of the source code
+- **Lazy Connections**: Auto-open on first request
 - **Stores State**: Reduces network traffic
 
 ### Developer Friendly

--- a/docs/user-guide/advanced-usage.md
+++ b/docs/user-guide/advanced-usage.md
@@ -127,17 +127,18 @@ All cached properties return `None` if no data has been cached yet, or the cache
 
 ## Connection Management
 
-### Understanding Connection Pooling
+### Understanding Lazy Connections
 
-lifx-async automatically pools connections for efficient reuse:
+Each device owns its own connection that opens lazily on first request:
 
 ```python
 from lifx import Light
 
 async def main():
     async with await Light.from_ip("192.168.1.100") as light:
-        # All these operations reuse the same connection
+        # Connection opens automatically on first request
         await light.set_power(True)
+        # All subsequent operations reuse the same connection
         await light.set_color(Colors.BLUE)
         await light.get_label()
         # Connection automatically closed when exiting context
@@ -145,9 +146,10 @@ async def main():
 
 **Benefits:**
 
-- Reduced overhead from socket creation/teardown
-- Lower latency for repeated operations
+- Simple lifecycle: one connection per device
+- Lazy opening: connection opens only when needed
 - Automatic cleanup on context exit
+- Requests are serialized to prevent response mixing
 
 ## Concurrency Patterns
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -272,7 +272,7 @@ async def measure_latency():
    )
    ```
 
-2. **Not using connection pooling**
+2. **Not reusing connections**
 
    Inefficient (creates new connection each time):
    ```python

--- a/src/lifx/const.py
+++ b/src/lifx/const.py
@@ -31,9 +31,6 @@ MAX_RESPONSE_TIME: Final[float] = 1.0  # 1 second
 # Idle timeout multiplier - wait this many times MAX_RESPONSE_TIME after last response
 IDLE_TIMEOUT_MULTIPLIER: Final[float] = 4.0  # 4 seconds (1.0 x 4.0)
 
-# Maximum number of connections in a ConnectionPool
-MAX_CONNECTIONS: Final[int] = 100
-
 # Default timeout for device requests in seconds
 DEFAULT_REQUEST_TIMEOUT: Final[float] = 8.0
 

--- a/src/lifx/network/__init__.py
+++ b/src/lifx/network/__init__.py
@@ -1,6 +1,6 @@
 """Network layer for LIFX device communication."""
 
-from lifx.network.connection import ConnectionPool, DeviceConnection
+from lifx.network.connection import DeviceConnection
 from lifx.network.discovery import DiscoveredDevice, discover_devices
 from lifx.network.message import MessageBuilder, create_message, parse_message
 from lifx.network.transport import UdpTransport
@@ -17,5 +17,4 @@ __all__ = [
     "discover_devices",
     # Connection
     "DeviceConnection",
-    "ConnectionPool",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import pytest
 from xprocess import ProcessStarter
 
 from lifx.api import DeviceGroup
-from lifx.network.connection import DeviceConnection
 
 
 def get_free_port() -> int:
@@ -161,50 +160,36 @@ def emulator_devices(emulator_server: int) -> DeviceGroup:
                 serial="d073d5000001",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
             Light(
                 serial="d073d5000002",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
             InfraredLight(
                 serial="d073d5000003",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
             HevLight(
                 serial="d073d5000004",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
             MultiZoneLight(
                 serial="d073d5000005",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
             MultiZoneLight(
                 serial="d073d5000006",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
             TileDevice(
                 serial="d073d5000007",
                 ip="127.0.0.1",
                 port=emulator_server,
-                timeout=1.0,
-                max_retries=1,
             ),
         ]
         return DeviceGroup(devices)
@@ -251,16 +236,17 @@ def allow_localhost_for_tests(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-async def cleanup_connection_pool():
-    """Clean up the connection pool after each test.
+async def cleanup_device_connections(emulator_devices):
+    """Clean up device connections after each test.
 
-    This ensures test isolation by closing all pooled connections
-    after each test completes. Without this, stale connections to
-    old mock server ports persist across tests.
+    This ensures test isolation by closing all device connections
+    after each test completes. Since each test has its own event loop,
+    connections must be closed so they can reopen with the new loop.
     """
     yield
-    # Close all connections in the pool after test completes
-    await DeviceConnection.close_all_connections()
+    # Close all device connections after test completes
+    for device in emulator_devices:
+        await device.connection.close()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
ConnectionPool and related classes have been removed. Each device now owns its own connection that opens lazily on first request.

This simplification removes ~350 lines of pool management code while maintaining full API compatibility. The architecture is now clearer: one device = one connection.

Changes:
- Remove ConnectionPool, ConnectionPoolMetrics, _ActualConnection classes
- Remove MAX_CONNECTIONS constant from const.py
- Add lazy connection opening with _is_opening flag to prevent races
- Create asyncio.Lock lazily in open() to bind to current event loop
- Update Device.__aexit__ to close connection on context exit
- Rewrite connection tests to remove pool-specific scenarios
- Update all documentation to reflect lazy connection pattern

Benefits:
- Simpler mental model (no LRU cache, no pool limits)
- Reduced code complexity (~350 fewer lines)
- No event loop binding issues (locks created lazily)
- Maintains concurrent device operations (different connections)
- Requests serialized per connection to prevent response mixing

All 775 tests pass with 0 type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)