### PR TITLE
fix: product registry generation

### DIFF
--- a/src/lifx/products/__init__.py
+++ b/src/lifx/products/__init__.py
@@ -14,7 +14,6 @@ from lifx.products.registry import (
     ProductInfo,
     ProductRegistry,
     TemperatureRange,
-    get_device_class_name,
     get_product,
     get_registry,
 )
@@ -24,7 +23,6 @@ __all__ = [
     "ProductInfo",
     "ProductRegistry",
     "TemperatureRange",
-    "get_device_class_name",
     "get_product",
     "get_registry",
 ]

--- a/src/lifx/products/generator.py
+++ b/src/lifx/products/generator.py
@@ -408,53 +408,6 @@ class ProductRegistry:
         """
         return self._products.get(pid)
 
-    def get_device_class_name(self, pid: int, firmware_version: int | None = None) -> str:
-        """Get appropriate device class name for a product.
-
-        Args:
-            pid: Product ID
-            firmware_version: Firmware version (optional)
-
-        Returns:
-            Device class name: "TileDevice", "MultiZoneLight", "HevLight", "InfraredLight", "Light", or "Device"
-        """
-        product = self.get_product(pid)
-        if product is None:
-            # Unknown product - default to Light if we don't know
-            return "Light"
-
-        # Matrix devices (Tiles, Candles) → TileDevice
-        if product.has_matrix:
-            return "TileDevice"
-
-        # MultiZone devices (Strips, Beams) → MultiZoneLight
-        if product.has_multizone:
-            return "MultiZoneLight"
-
-        # HEV lights → HevLight
-        if product.has_hev:
-            return "HevLight"
-
-        # Infrared lights → InfraredLight
-        if product.has_infrared:
-            return "InfraredLight"
-
-        # Color lights → Light
-        if product.has_color:
-            return "Light"
-
-        # Devices with relays (switches/relays) → Device
-        if product.has_relays:
-            return "Device"
-
-        # Devices with buttons but no color (switches) → Device
-        if product.has_buttons:
-            return "Device"
-
-        # Everything else (basic lights, white-to-warm lights) → Light
-        # These have no special capabilities but still support Light protocol
-        return "Light"
-
     def __len__(self) -> int:
         """Get number of products in registry."""
         return len(self._products)
@@ -477,29 +430,27 @@ def get_registry() -> ProductRegistry:
     return _registry
 
 
-def get_product(pid: int) -> ProductInfo | None:
+def get_product(pid: int) -> ProductInfo:
     """Get product info by product ID.
 
     Args:
         pid: Product ID
 
     Returns:
-        ProductInfo if found, None otherwise
+        ProductInfo if found, otherwise a default ProductInfo with no capabilities
     """
-    return _registry.get_product(pid)
-
-
-def get_device_class_name(pid: int, firmware_version: int | None = None) -> str:
-    """Get appropriate device class name for a product.
-
-    Args:
-        pid: Product ID
-        firmware_version: Firmware version (optional)
-
-    Returns:
-        Device class name: "TileDevice", "MultiZoneLight", "Light", or "Device"
-    """
-    return _registry.get_device_class_name(pid, firmware_version)
+    product = _registry.get_product(pid)
+    if product is None:
+        # Return default product with no capabilities for unknown products
+        return ProductInfo(
+            pid=0,
+            name="LIFX Light",
+            vendor=1,
+            capabilities=0,
+            temperature_range=None,
+            min_ext_mz_firmware=None,
+        )
+    return product
 '''
 
     return header + products_code + helper_functions

--- a/src/lifx/products/registry.py
+++ b/src/lifx/products/registry.py
@@ -1383,55 +1383,6 @@ class ProductRegistry:
         """
         return self._products.get(pid)
 
-    def get_device_class_name(
-        self, pid: int, firmware_version: int | None = None
-    ) -> str:
-        """Get appropriate device class name for a product.
-
-        Args:
-            pid: Product ID
-            firmware_version: Firmware version (optional)
-
-        Returns:
-            Device class name: "TileDevice", "MultiZoneLight", "HevLight", "InfraredLight", "Light", or "Device"
-        """
-        product = self.get_product(pid)
-        if product is None:
-            # Unknown product - default to Light if we don't know
-            return "Light"
-
-        # Matrix devices (Tiles, Candles) → TileDevice
-        if product.has_matrix:
-            return "TileDevice"
-
-        # MultiZone devices (Strips, Beams) → MultiZoneLight
-        if product.has_multizone:
-            return "MultiZoneLight"
-
-        # HEV lights → HevLight
-        if product.has_hev:
-            return "HevLight"
-
-        # Infrared lights → InfraredLight
-        if product.has_infrared:
-            return "InfraredLight"
-
-        # Color lights → Light
-        if product.has_color:
-            return "Light"
-
-        # Devices with relays (switches/relays) → Device
-        if product.has_relays:
-            return "Device"
-
-        # Devices with buttons but no color (switches) → Device
-        if product.has_buttons:
-            return "Device"
-
-        # Everything else (basic lights, white-to-warm lights) → Light
-        # These have no special capabilities but still support Light protocol
-        return "Light"
-
     def __len__(self) -> int:
         """Get number of products in registry."""
         return len(self._products)
@@ -1454,26 +1405,24 @@ def get_registry() -> ProductRegistry:
     return _registry
 
 
-def get_product(pid: int) -> ProductInfo | None:
+def get_product(pid: int) -> ProductInfo:
     """Get product info by product ID.
 
     Args:
         pid: Product ID
 
     Returns:
-        ProductInfo if found, None otherwise
+        ProductInfo if found, otherwise a default ProductInfo with no capabilities
     """
-    return _registry.get_product(pid)
-
-
-def get_device_class_name(pid: int, firmware_version: int | None = None) -> str:
-    """Get appropriate device class name for a product.
-
-    Args:
-        pid: Product ID
-        firmware_version: Firmware version (optional)
-
-    Returns:
-        Device class name: "TileDevice", "MultiZoneLight", "Light", or "Device"
-    """
-    return _registry.get_device_class_name(pid, firmware_version)
+    product = _registry.get_product(pid)
+    if product is None:
+        # Return default product with no capabilities for unknown products
+        return ProductInfo(
+            pid=0,
+            name="LIFX Light",
+            vendor=1,
+            capabilities=0,
+            temperature_range=None,
+            min_ext_mz_firmware=None,
+        )
+    return product

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,98 +148,48 @@ def emulator_devices(emulator_server: int) -> DeviceGroup:
         - 2 MultiZoneLight devices (d073d5000005, d073d5000006)
         - 1 MatrixLight (d073d5000007)
     """
-    # import ipaddress
-
-    # # Temporarily allow localhost for device creation
-    # original_is_loopback = ipaddress.IPv4Address.is_loopback.fget
-
-    # def fake_is_loopback(_addr_self):
-    #     return False
-
-    # # Patch the property
-    # ipaddress.IPv4Address.is_loopback = property(fake_is_loopback)
     devices: list[Device] = []
 
-    try:
-        devices.extend(
-            [
-                Light(
-                    serial="d073d5000001",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-                Light(
-                    serial="d073d5000002",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-                InfraredLight(
-                    serial="d073d5000003",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-                HevLight(
-                    serial="d073d5000004",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-                MultiZoneLight(
-                    serial="d073d5000005",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-                MultiZoneLight(
-                    serial="d073d5000006",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-                MatrixLight(
-                    serial="d073d5000007",
-                    ip="127.0.0.1",
-                    port=emulator_server,
-                ),
-            ]
-        )
-        return DeviceGroup(devices)
-    finally:
-        pass
-
-        # Restore original
-        # ipaddress.IPv4Address.is_loopback = property(original_is_loopback)
-
-
-# @pytest.fixture(autouse=True)
-# def allow_localhost_for_tests(monkeypatch):
-#     """Allow localhost IPs for testing with emulator.
-
-#     The Device class normally rejects localhost IPs, but for testing with
-#     the emulator running on 127.0.0.1, we need to bypass this validation.
-#     """
-
-#     original_init = Device.__init__
-
-#     def patched_init(self, *args, **kwargs):
-#         # Temporarily replace is_loopback check
-#         original_is_loopback = ipaddress.IPv4Address.is_loopback.fget
-
-#         def fake_is_loopback(_addr_self):
-#             # Allow loopback addresses in tests
-#             return False
-
-#         # Monkeypatch the property
-#         monkeypatch.setattr(
-#             ipaddress.IPv4Address, "is_loopback", property(fake_is_loopback)
-#         )
-
-#         try:
-#             original_init(self, *args, **kwargs)
-#         finally:
-#             # Restore original
-#             monkeypatch.setattr(
-#                 ipaddress.IPv4Address, "is_loopback", property(original_is_loopback)
-#             )
-
-#     monkeypatch.setattr(Device, "__init__", patched_init)
+    devices.extend(
+        [
+            Light(
+                serial="d073d5000001",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+            Light(
+                serial="d073d5000002",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+            InfraredLight(
+                serial="d073d5000003",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+            HevLight(
+                serial="d073d5000004",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+            MultiZoneLight(
+                serial="d073d5000005",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+            MultiZoneLight(
+                serial="d073d5000006",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+            MatrixLight(
+                serial="d073d5000007",
+                ip="127.0.0.1",
+                port=emulator_server,
+            ),
+        ]
+    )
+    return DeviceGroup(devices)
 
 
 @pytest.fixture(autouse=True)
@@ -304,15 +254,6 @@ def ceiling_device(emulator_server: int, emulator_api_url: str):
     )
     response.raise_for_status()  # 201 Created is expected
 
-    # # Temporarily allow localhost for device creation
-    # original_is_loopback = ipaddress.IPv4Address.is_loopback.fget
-
-    # def fake_is_loopback(_addr_self):
-    #     return False
-
-    # # Patch the property
-    # ipaddress.IPv4Address.is_loopback = property(fake_is_loopback)
-
     try:
         ceiling = MatrixLight(
             serial="d073d5000100",
@@ -321,9 +262,6 @@ def ceiling_device(emulator_server: int, emulator_api_url: str):
         )
         yield ceiling
     finally:
-        # Restore original
-        # ipaddress.IPv4Address.is_loopback = property(original_is_loopback)
-
         # Clean up: delete the device
         try:
             requests.delete(

--- a/tests/test_products/test_product_generator.py
+++ b/tests/test_products/test_product_generator.py
@@ -481,7 +481,6 @@ class TestGenerateRegistryFile:
         assert "def __init__" in code
         assert "def load_from_dict" in code
         assert "def get_product" in code
-        assert "def get_device_class_name" in code
 
         # Check product definitions
         assert "PRODUCTS: dict[int, ProductInfo]" in code
@@ -489,7 +488,6 @@ class TestGenerateRegistryFile:
         # Check helper functions
         assert "def get_registry()" in code
         assert "def get_product(pid: int)" in code
-        assert "def get_device_class_name(pid: int" in code
 
     def test_registry_file_has_product_info_methods(
         self, minimal_products_data: dict
@@ -519,7 +517,6 @@ class TestGenerateRegistryFile:
         # Check registry methods
         assert "def is_loaded(self) -> bool:" in code
         assert "def get_product(self, pid: int)" in code
-        assert "def get_device_class_name(self, pid: int" in code
         assert "def __len__(self)" in code
         assert "def __contains__(self, pid: int)" in code
 

--- a/tests/test_products/test_registry.py
+++ b/tests/test_products/test_registry.py
@@ -9,7 +9,6 @@ from lifx.products import (
     ProductInfo,
     ProductRegistry,
     TemperatureRange,
-    get_device_class_name,
     get_registry,
 )
 
@@ -225,53 +224,6 @@ class TestProductRegistry:
         assert 31 in registry
         assert 999 not in registry
 
-    def test_get_device_class_name_tile(self, registry: ProductRegistry) -> None:
-        """Test device class for tile products."""
-        class_name = registry.get_device_class_name(55)  # LIFX Tile
-        assert class_name == "TileDevice"
-
-    def test_get_device_class_name_multizone(self, registry: ProductRegistry) -> None:
-        """Test device class for multizone products."""
-        class_name = registry.get_device_class_name(31)  # LIFX Z
-        assert class_name == "MultiZoneLight"
-
-    def test_get_device_class_name_hev(self, registry: ProductRegistry) -> None:
-        """Test device class for HEV products."""
-        class_name = registry.get_device_class_name(90)  # LIFX Clean
-        assert class_name == "HevLight"
-
-    def test_get_device_class_name_infrared(self, registry: ProductRegistry) -> None:
-        """Test device class for infrared products."""
-        class_name = registry.get_device_class_name(29)  # LIFX A19 Night Vision
-        assert class_name == "InfraredLight"
-
-    def test_get_device_class_name_light(self, registry: ProductRegistry) -> None:
-        """Test device class for color lights."""
-        class_name = registry.get_device_class_name(1)  # LIFX Original
-        assert class_name == "Light"
-
-    def test_get_device_class_name_white_light(self, registry: ProductRegistry) -> None:
-        """Test device class for basic white lights (brightness-only)."""
-        class_name = registry.get_device_class_name(10)  # LIFX White 800
-        assert class_name == "Light"
-
-    def test_get_device_class_name_white_to_warm(
-        self, registry: ProductRegistry
-    ) -> None:
-        """Test device class for white-to-warm lights (brightness + temperature)."""
-        class_name = registry.get_device_class_name(11)  # LIFX White to Warm 800
-        assert class_name == "Light"
-
-    def test_get_device_class_name_device(self, registry: ProductRegistry) -> None:
-        """Test device class for non-light products (switches)."""
-        class_name = registry.get_device_class_name(89)  # LIFX Switch
-        assert class_name == "Device"
-
-    def test_get_device_class_name_unknown(self, registry: ProductRegistry) -> None:
-        """Test device class for unknown product."""
-        class_name = registry.get_device_class_name(999)
-        assert class_name == "Light"  # Default to Light
-
     def test_load_array_format(self) -> None:
         """Test loading array format (multiple vendors)."""
         data = [
@@ -323,38 +275,3 @@ class TestGlobalFunctions:
         """Test getting global registry."""
         reg = get_registry()
         assert isinstance(reg, ProductRegistry)
-
-    def test_get_device_class_name_with_registry(
-        self, registry: ProductRegistry
-    ) -> None:
-        """Test get_device_class_name function with test registry."""
-        # Test with the sample registry fixture
-        assert registry.get_device_class_name(55) == "TileDevice"
-        assert registry.get_device_class_name(31) == "MultiZoneLight"
-        assert registry.get_device_class_name(90) == "HevLight"
-        assert registry.get_device_class_name(29) == "InfraredLight"
-        assert registry.get_device_class_name(1) == "Light"
-        assert registry.get_device_class_name(10) == "Light"  # White (brightness-only)
-        assert registry.get_device_class_name(11) == "Light"  # White to Warm
-        assert registry.get_device_class_name(89) == "Device"
-
-    def test_get_device_class_name_global(self) -> None:
-        """Test global get_device_class_name function uses pre-loaded registry."""
-        # The global registry should be pre-loaded
-        reg = get_registry()
-        assert reg.is_loaded
-        assert len(reg) > 0
-
-        # Test that function works (using actual product IDs from generated registry)
-        # We can't predict exact PIDs, but we can verify it returns valid class names
-        valid_classes = {
-            "TileDevice",
-            "MultiZoneLight",
-            "HevLight",
-            "InfraredLight",
-            "Light",
-            "Device",
-        }
-        for pid in [1, 10, 27, 31, 55]:  # Common LIFX product IDs
-            class_name = get_device_class_name(pid)
-            assert class_name in valid_classes

--- a/tests/test_theme/conftest.py
+++ b/tests/test_theme/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from lifx.devices.base import DeviceVersion
 from lifx.devices.light import Light
 from lifx.devices.matrix import MatrixLight
 from lifx.devices.multizone import MultiZoneLight
@@ -31,6 +32,7 @@ def mock_device_factory():
         mock_conn.request = AsyncMock()
         mock_conn.request_ack = AsyncMock()
         device.connection = mock_conn
+        device._version = DeviceVersion(vendor=1, product=27)
         return device
 
     return _create_device
@@ -50,6 +52,7 @@ def light(mock_device_factory) -> Light:
 def multizone_light(mock_device_factory) -> MultiZoneLight:
     """Create a test multizone light with mocked theme methods."""
     light = mock_device_factory(MultiZoneLight)
+    light.set_color = AsyncMock()
     light.set_extended_color_zones = AsyncMock()
     light.set_power = AsyncMock()
     light.get_power = AsyncMock(return_value=False)
@@ -61,6 +64,7 @@ def multizone_light(mock_device_factory) -> MultiZoneLight:
 def matrix_light(mock_device_factory) -> MatrixLight:
     """Create a test matrix light with mocked theme methods."""
     device = mock_device_factory(MatrixLight)
+    device.set_color = AsyncMock()
     device.set_matrix_colors = AsyncMock()
     device.set_power = AsyncMock()
     device.get_power = AsyncMock(return_value=False)

--- a/tests/test_theme/test_apply_theme.py
+++ b/tests/test_theme/test_apply_theme.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+from lifx.api import DeviceGroup
 from lifx.color import HSBK, Colors
-from lifx.devices.light import Light
 from lifx.devices.matrix import MatrixLight
 from lifx.devices.multizone import MultiZoneLight
 from lifx.theme import Theme
@@ -14,12 +14,12 @@ from lifx.theme import Theme
 class TestLightApplyTheme:
     """Tests for Light.apply_theme method."""
 
-    def test_apply_theme_basic(self, light: Light) -> None:
-        """Test creating a light for apply_theme tests."""
-        assert light.serial == "d073d5010203"
-
-    async def test_apply_theme_selects_random_color(self, light: Light) -> None:
+    async def test_apply_theme_selects_random_color(
+        self, emulator_devices: DeviceGroup
+    ) -> None:
         """Test that apply_theme selects a random color from theme."""
+        light = emulator_devices[0]
+
         light.set_color = AsyncMock()
         light.set_power = AsyncMock()
         light.get_power = AsyncMock(return_value=False)
@@ -36,8 +36,16 @@ class TestLightApplyTheme:
         # Verify set_power was not called
         light.set_power.assert_not_called()
 
-    async def test_apply_theme_with_duration(self, light: Light) -> None:
+        light.set_color.reset_mock()
+        light.set_power.reset_mock()
+        light.get_power.reset_mock()
+
+    async def test_apply_theme_with_duration(
+        self, emulator_devices: DeviceGroup
+    ) -> None:
         """Test apply_theme with transition duration."""
+        light = emulator_devices[0]
+
         light.get_power = AsyncMock(return_value=True)
         theme = Theme([Colors.RED, Colors.BLUE])
 
@@ -47,8 +55,17 @@ class TestLightApplyTheme:
         args, kwargs = light.set_color.call_args
         assert kwargs.get("duration", 0.0) == 1.5
 
-    async def test_apply_theme_with_power_on(self, light: Light) -> None:
+        light.set_color.reset_mock()
+        light.set_power.reset_mock()
+        light.get_power.reset_mock()
+
+    async def test_apply_theme_with_power_on(
+        self, emulator_devices: DeviceGroup
+    ) -> None:
         """Test apply_theme with power_on=True."""
+        light = emulator_devices[0]
+        light.get_power = AsyncMock(return_value=False)
+
         theme = Theme([Colors.RED])
 
         await light.apply_theme(theme, power_on=True)
@@ -59,8 +76,16 @@ class TestLightApplyTheme:
         args, kwargs = light.set_power.call_args
         assert args[0] is True
 
-    async def test_apply_theme_color_from_theme(self, light: Light) -> None:
+        light.set_color.reset_mock()
+        light.set_power.reset_mock()
+        light.get_power.reset_mock()
+
+    async def test_apply_theme_color_from_theme(
+        self, emulator_devices: DeviceGroup
+    ) -> None:
         """Test that apply_theme receives a color from the theme."""
+        light = emulator_devices[0]
+
         original_color = HSBK(hue=45, saturation=0.8, brightness=0.9, kelvin=4000)
         theme = Theme([original_color])
 
@@ -75,6 +100,10 @@ class TestLightApplyTheme:
         assert applied_color.saturation == original_color.saturation
         assert applied_color.brightness == original_color.brightness
         assert applied_color.kelvin == original_color.kelvin
+
+        light.set_color.reset_mock()
+        light.set_power.reset_mock()
+        light.get_power.reset_mock()
 
 
 class TestMultiZoneLightApplyTheme:


### PR DESCRIPTION
Remove the get_device_class_name function from the products module public API. Device type detection is now exclusively handled internally by DiscoveredDevice.create_device() using capability-based logic. This simplifies the API surface and eliminates redundant device detection paths.

Modify get_product() to always return a ProductInfo object instead of None. When a product ID is not found in the registry, it now returns a default ProductInfo(pid=0, name="LIFX Light", vendor=1, capabilities=0) with no capabilities.

This change eliminates the need for null checks in calling code and provides a safe fallback for unknown products, simplifying error handling throughout the codebase.

Changes:
- Update get_product() signature from ProductInfo | None to ProductInfo
- Add fallback logic to return default ProductInfo when product not found
- Regenerate registry.py with updated implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)