### PR TITLE
fix(devices): raise LifxUnsupportedCommandError on StateUnhandled responses

### DIFF
--- a/src/lifx/devices/hev.py
+++ b/src/lifx/devices/hev.py
@@ -70,6 +70,7 @@ class HevLight(Light):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -82,6 +83,7 @@ class HevLight(Light):
         """
         # Request HEV cycle state
         state = await self.connection.request(packets.Light.GetHevCycle())
+        self._raise_if_unhandled(state)
 
         # Create state object
         cycle_state = HevCycleState(
@@ -116,6 +118,7 @@ class HevLight(Light):
             ValueError: If duration is negative
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -130,12 +133,13 @@ class HevLight(Light):
             raise ValueError(f"Duration must be non-negative, got {duration_seconds}")
 
         # Request automatically handles acknowledgement
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetHevCycle(
                 enable=enable,
                 duration_s=duration_seconds,
             ),
         )
+        self._raise_if_unhandled(result)
 
         _LOGGER.debug(
             {
@@ -156,6 +160,7 @@ class HevLight(Light):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -166,6 +171,7 @@ class HevLight(Light):
         """
         # Request HEV configuration
         state = await self.connection.request(packets.Light.GetHevCycleConfiguration())
+        self._raise_if_unhandled(state)
 
         # Create config object
         config = HevConfig(
@@ -201,6 +207,7 @@ class HevLight(Light):
             ValueError: If duration is negative
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -212,12 +219,13 @@ class HevLight(Light):
             raise ValueError(f"Duration must be non-negative, got {duration_seconds}")
 
         # Request automatically handles acknowledgement
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetHevCycleConfiguration(
                 indication=indication,
                 duration_s=duration_seconds,
             ),
         )
+        self._raise_if_unhandled(result)
 
         # Update cached state
         self._hev_config = HevConfig(indication=indication, duration_s=duration_seconds)
@@ -242,6 +250,7 @@ class HevLight(Light):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -254,6 +263,7 @@ class HevLight(Light):
         """
         # Request last HEV result
         state = await self.connection.request(packets.Light.GetLastHevCycleResult())
+        self._raise_if_unhandled(state)
 
         # Store cached state
         self._hev_result = state.result

--- a/src/lifx/devices/infrared.py
+++ b/src/lifx/devices/infrared.py
@@ -58,6 +58,7 @@ class InfraredLight(Light):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -68,6 +69,7 @@ class InfraredLight(Light):
         """
         # Request infrared state
         state = await self.connection.request(packets.Light.GetInfrared())
+        self._raise_if_unhandled(state)
 
         # Convert from uint16 (0-65535) to float (0.0-1.0)
         brightness = state.brightness / 65535.0
@@ -96,6 +98,7 @@ class InfraredLight(Light):
             ValueError: If brightness is out of range
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -115,9 +118,10 @@ class InfraredLight(Light):
         brightness_u16 = max(0, min(65535, int(round(brightness * 65535))))
 
         # Request automatically handles acknowledgement
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetInfrared(brightness=brightness_u16),
         )
+        self._raise_if_unhandled(result)
 
         # Update cached state
         self._infrared = brightness

--- a/src/lifx/devices/light.py
+++ b/src/lifx/devices/light.py
@@ -83,6 +83,7 @@ class Light(Device):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -92,6 +93,7 @@ class Light(Device):
         """
         # Request automatically unpacks response and decodes labels
         state = await self.connection.request(packets.Light.GetColor())
+        self._raise_if_unhandled(state)
 
         # Convert from protocol HSBK to user-friendly HSBK
         color = HSBK.from_protocol(state.color)
@@ -133,6 +135,7 @@ class Light(Device):
         Raises:
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -150,12 +153,13 @@ class Light(Device):
         duration_ms = int(duration * 1000)
 
         # Request automatically handles acknowledgement
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetColor(
                 color=protocol_color,
                 duration=duration_ms,
             ),
         )
+        self._raise_if_unhandled(result)
 
         _LOGGER.debug(
             {
@@ -357,6 +361,7 @@ class Light(Device):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -366,6 +371,7 @@ class Light(Device):
         """
         # Request automatically unpacks response
         state = await self.connection.request(packets.Light.GetPower())
+        self._raise_if_unhandled(state)
 
         # Power level is uint16 (0 or 65535)
         _LOGGER.debug(
@@ -394,6 +400,7 @@ class Light(Device):
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
             LifxProtocolError: If response is invalid
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -406,6 +413,7 @@ class Light(Device):
         """
         # Request automatically unpacks response
         state = await self.connection.request(packets.Sensor.GetAmbientLight())
+        self._raise_if_unhandled(state)
 
         _LOGGER.debug(
             {
@@ -432,6 +440,7 @@ class Light(Device):
             ValueError: If integer value is not 0 or 65535
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -460,9 +469,10 @@ class Light(Device):
         duration_ms = int(duration * 1000)
 
         # Request automatically handles acknowledgement
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetPower(level=power_level, duration=duration_ms),
         )
+        self._raise_if_unhandled(result)
 
         _LOGGER.debug(
             {
@@ -499,6 +509,7 @@ class Light(Device):
             ValueError: If parameters are out of range
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -537,7 +548,7 @@ class Light(Device):
         skew_ratio_i16 = int(skew_ratio * 65535) - 32768  # Convert to int16 range
 
         # Send request
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetWaveform(
                 transient=bool(transient),
                 color=protocol_color,
@@ -547,6 +558,7 @@ class Light(Device):
                 waveform=waveform,
             ),
         )
+        self._raise_if_unhandled(result)
         _LOGGER.debug(
             {
                 "class": "Device",
@@ -602,6 +614,7 @@ class Light(Device):
             ValueError: If parameters are out of range
             LifxDeviceNotFoundError: If device is not connected
             LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
 
         Example:
             ```python
@@ -647,7 +660,7 @@ class Light(Device):
         skew_ratio_i16 = int(skew_ratio * 65535) - 32768  # Convert to int16 range
 
         # Send request
-        await self.connection.request(
+        result = await self.connection.request(
             packets.Light.SetWaveformOptional(
                 transient=bool(transient),
                 color=protocol_color,
@@ -661,6 +674,7 @@ class Light(Device):
                 set_kelvin=set_kelvin,
             ),
         )
+        self._raise_if_unhandled(result)
         _LOGGER.debug(
             {
                 "class": "Device",

--- a/src/lifx/devices/matrix.py
+++ b/src/lifx/devices/matrix.py
@@ -311,6 +311,11 @@ class MatrixLight(Light):
         Returns:
             List of TileInfo objects describing each tile in the chain
 
+        Raises:
+            LifxDeviceNotFoundError: If device is not connected
+            LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
+
         Example:
             >>> chain = await matrix.get_device_chain()
             >>> for tile in chain:
@@ -321,6 +326,7 @@ class MatrixLight(Light):
         response: packets.Tile.StateDeviceChain = await self.connection.request(
             packets.Tile.GetDeviceChain()
         )
+        self._raise_if_unhandled(response)
 
         # Parse tiles from response
         tiles = []
@@ -393,6 +399,11 @@ class MatrixLight(Light):
             returns the actual zone count (e.g., 64 for 8x8, 16 for 4x4). For tiles
             with >64 zones (e.g., 128 for 16x8 Ceiling), returns 64 (protocol limit).
 
+        Raises:
+            LifxDeviceNotFoundError: If device is not connected
+            LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
+
         Example:
             >>> # Get all colors from first tile (no parameters needed)
             >>> colors = await matrix.get64()
@@ -432,6 +443,7 @@ class MatrixLight(Light):
                 rect=TileBufferRect(fb_index=0, x=x, y=y, width=width),
             )
         )
+        self._raise_if_unhandled(response)
 
         max_colors = device_chain[0].width * device_chain[0].height
 
@@ -714,6 +726,11 @@ class MatrixLight(Light):
         Returns:
             MatrixEffect describing the current effect state
 
+        Raises:
+            LifxDeviceNotFoundError: If device is not connected
+            LifxTimeoutError: If device does not respond
+            LifxUnsupportedCommandError: If device doesn't support this command
+
         Example:
             >>> effect = await matrix.get_effect()
             >>> print(f"Effect type: {effect.effect_type}")
@@ -723,6 +740,7 @@ class MatrixLight(Light):
         response: packets.Tile.StateEffect = await self.connection.request(
             packets.Tile.GetEffect()
         )
+        self._raise_if_unhandled(response)
 
         # Convert protocol effect to MatrixEffect
         palette = [

--- a/tests/test_devices/test_light.py
+++ b/tests/test_devices/test_light.py
@@ -480,3 +480,67 @@ class TestLight:
         repr_str = repr(light)
         assert "Light" in repr_str
         assert "192.168.1.100" in repr_str
+
+
+class TestLightStateUnhandled:
+    """Tests for Light methods raising LifxUnsupportedCommandError on StateUnhandled."""
+
+    @pytest.mark.emulator
+    async def test_get_color_raises_on_state_unhandled(self, switch_device) -> None:
+        """Test get_color() raises LifxUnsupportedCommandError for unsupported device.
+
+        Switch devices don't support Light commands, so get_color() should
+        raise LifxUnsupportedCommandError when the device returns StateUnhandled.
+        """
+        from lifx.exceptions import LifxUnsupportedCommandError
+
+        # Create a Light instance using the switch connection (without context manager)
+        light = Light(
+            serial=switch_device.serial,
+            ip=switch_device.ip,
+            port=switch_device.port,
+        )
+
+        # Manually open the connection
+        await light.connection.open()
+
+        try:
+            # get_color() should raise LifxUnsupportedCommandError
+            with pytest.raises(LifxUnsupportedCommandError) as exc_info:
+                await light.get_color()
+
+            # Verify the exception message contains the packet type
+            assert "packet type" in str(exc_info.value).lower()
+        finally:
+            await light.connection.close()
+
+    @pytest.mark.emulator
+    async def test_set_color_raises_on_state_unhandled(self, switch_device) -> None:
+        """Test set_color() raises LifxUnsupportedCommandError for unsupported device.
+
+        Switch devices don't support Light commands, so set_color() should
+        raise LifxUnsupportedCommandError when the device returns StateUnhandled.
+        """
+        from lifx.exceptions import LifxUnsupportedCommandError
+
+        # Create a Light instance using the switch connection (without context manager)
+        light = Light(
+            serial=switch_device.serial,
+            ip=switch_device.ip,
+            port=switch_device.port,
+        )
+
+        # Manually open the connection
+        await light.connection.open()
+
+        try:
+            color = HSBK(hue=120, saturation=1.0, brightness=1.0, kelvin=3500)
+
+            # set_color() should raise LifxUnsupportedCommandError
+            with pytest.raises(LifxUnsupportedCommandError) as exc_info:
+                await light.set_color(color)
+
+            # Verify the exception message indicates unsupported command
+            assert "does not support" in str(exc_info.value).lower()
+        finally:
+            await light.connection.close()


### PR DESCRIPTION
Add `_raise_if_unhandled()` static method to Device base class that checks for `StateUnhandled` packets or `False` returns from connection.request() and raises LifxUnsupportedCommandError. Updated all `get_*/set_*` methods across device classes to use this check:

- Device: get_label, set_label, get_power, set_power, get_version, get_info, get_wifi_info, get_host_firmware, get_wifi_firmware, get_location, set_location, get_group, set_group, set_reboot
- Light: get_color, set_color, get_power, get_ambient_light_level, set_power, set_waveform, set_waveform_optional
- HevLight: get_hev_cycle, set_hev_cycle, get_hev_config, set_hev_config, get_last_hev_result
- InfraredLight: get_infrared, set_infrared
- MultiZoneLight: get_zone_count, get_color_zones, get_extended_color_zones, set_color_zones, set_extended_color_zones, get_effect, set_effect
- MatrixLight: get_device_chain, get64, get_effect

Added emulator-based tests to verify get_color() and set_color() raise LifxUnsupportedCommandError when sent to a Switch device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)