### PR TITLE
fix(network): raise exception on StateUnhandled instead of returning False

### DIFF
--- a/src/lifx/devices/base.py
+++ b/src/lifx/devices/base.py
@@ -166,8 +166,6 @@ class Device:
             raise LifxUnsupportedCommandError(
                 f"Device does not support packet type {response.unhandled_type}"
             )
-        if response is False:
-            raise LifxUnsupportedCommandError("Device does not support this command")
 
     def __init__(
         self,

--- a/src/lifx/network/connection.py
+++ b/src/lifx/network/connection.py
@@ -22,6 +22,7 @@ from lifx.exceptions import (
     LifxConnectionError,
     LifxProtocolError,
     LifxTimeoutError,
+    LifxUnsupportedCommandError,
 )
 from lifx.network.message import create_message, parse_message
 from lifx.network.transport import UdpTransport
@@ -722,8 +723,9 @@ class DeviceConnection:
 
                 # Check for StateUnhandled - return False to indicate unsupported
                 if header.pkt_type == _STATE_UNHANDLED_PKT_TYPE:
-                    yield False
-                    return
+                    raise LifxUnsupportedCommandError(
+                        "Device does not support this command"
+                    )
 
                 # ACK received successfully
                 yield True

--- a/tests/test_network/test_connection.py
+++ b/tests/test_network/test_connection.py
@@ -572,11 +572,12 @@ class TestStateUnhandledResponses:
             assert response.unhandled_type == packets.Light.GetColor.PKT_TYPE
 
     @pytest.mark.emulator
-    async def test_set_color_returns_false_for_switch(self, switch_device) -> None:
-        """Test SetColor to a Switch device returns False.
+    async def test_set_color_raises_for_switch(self, switch_device) -> None:
+        """Test SetColor to a Switch device raises LifxUnsupportedCommandError.
 
         Switch devices don't support Light commands, so SetColor should
-        return False (indicating StateUnhandled) instead of True (ACK).
+        raise LifxUnsupportedCommandError. We don't return False, because
+        that means the Acknowledgement timed out.
         """
         from lifx.color import HSBK
         from lifx.protocol import packets
@@ -589,8 +590,6 @@ class TestStateUnhandledResponses:
                 duration=0,
             )
 
-            # Send SetColor to a Switch - should return False (StateUnhandled)
-            result = await switch_device.request(set_packet)
-
-            # Should return False, not True or raise an exception
-            assert result is False
+            with pytest.raises(LifxUnsupportedCommandError):
+                # Send SetColor to a Switch, should raise LifxUnsupportedCommandError
+                await switch_device.request(set_packet)


### PR DESCRIPTION
Returning False for StateUnhandled was ambiguous since False typically indicates an acknowledgement timeout. Now raises LifxUnsupportedCommandError to clearly distinguish between "command not supported" and "no response".

🤖 Generated with [Claude Code](https://claude.com/claude-code)