### PR TITLE
test(ci): restrict emulator tests to Linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
       run: uv run --frozen pytest
 
     - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
       with:
         env_vars: OS,PYTHON
@@ -105,6 +106,7 @@ jobs:
         verbose: true
 
     - name: Upload test results to Codecov
+      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
       with:
         env_vars: OS,PYTHON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ addopts = """\
     """
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "emulator: tests that require the lifx-emulator (only run on Linux)",
+]
 
 [tool.coverage.run]
 omit = [

--- a/tests/test_api/test_api_batch_errors.py
+++ b/tests/test_api/test_api_batch_errors.py
@@ -19,6 +19,7 @@ from lifx.devices import Light
 from tests.conftest import get_free_port
 
 
+@pytest.mark.emulator
 class TestBatchOperationPartialFailures:
     """Test batch operations with partial failures."""
 
@@ -54,6 +55,7 @@ class TestBatchOperationPartialFailures:
         )
 
 
+@pytest.mark.emulator
 class TestBatchOperationScalability:
     """Test batch operations with large numbers of devices."""
 
@@ -71,6 +73,7 @@ class TestBatchOperationScalability:
         assert is_on
 
 
+@pytest.mark.emulator
 class TestBatchOperationConcurrency:
     """Test batch operation concurrent execution."""
 
@@ -93,6 +96,7 @@ class TestBatchOperationConcurrency:
             assert is_on, f"Device {i} should be on"
 
 
+@pytest.mark.emulator
 class TestBatchOperationEdgeCases:
     """Test edge cases for batch operations."""
 
@@ -171,6 +175,7 @@ class TestBatchOperationEdgeCases:
         assert is_on  # Real device should be on
 
 
+@pytest.mark.emulator
 class TestBatchOperationErrorDetails:
     """Test detailed error information from batch operations."""
 

--- a/tests/test_api/test_api_batch_operations.py
+++ b/tests/test_api/test_api_batch_operations.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from lifx.api import DeviceGroup
 from lifx.color import HSBK
 
 
+@pytest.mark.emulator
 class TestDeviceGroupBatchOperations:
     """Test DeviceGroup batch operations."""
 

--- a/tests/test_api/test_api_discovery.py
+++ b/tests/test_api/test_api_discovery.py
@@ -17,6 +17,7 @@ from lifx.network.discovery import discover_devices
 from tests.conftest import get_free_port
 
 
+@pytest.mark.emulator
 class TestDiscover:
     """Test discover() async generator."""
 
@@ -51,6 +52,7 @@ class TestDiscover:
             pytest.fail(f"Unexpected yield of {device} from discover.")
 
 
+@pytest.mark.emulator
 class TestFindBySerial:
     """Test find_by_serial() helper function."""
 
@@ -165,6 +167,7 @@ class TestFindBySerial:
         assert device is None
 
 
+@pytest.mark.emulator
 class TestFindByIp:
     """Tests for find_by_ip function."""
 
@@ -205,6 +208,7 @@ class TestFindByIp:
         assert device is None
 
 
+@pytest.mark.emulator
 class TestFindByLabel:
     """Tests for find_by_label function."""
 

--- a/tests/test_api/test_api_organization.py
+++ b/tests/test_api/test_api_organization.py
@@ -20,6 +20,7 @@ import pytest
 from lifx.api import DeviceGroup
 
 
+@pytest.mark.emulator
 class TestOrganizeMetadata:
     """Test organization by location and group metadata."""
 
@@ -65,6 +66,7 @@ class TestOrganizeMetadata:
         assert by_metadata1 is by_metadata2
 
 
+@pytest.mark.emulator
 class TestFilterMetadata:
     """Test filtering by location and group metadata."""
 
@@ -124,6 +126,7 @@ class TestFilterMetadata:
             await filter_func(error_name)
 
 
+@pytest.mark.emulator
 class TestGetUnassignedDevices:
     """Test get_unassigned_devices() method."""
 
@@ -171,6 +174,7 @@ class TestGetUnassignedDevices:
             fresh_group.get_unassigned_devices(metadata_type=metadata_type)
 
 
+@pytest.mark.emulator
 class TestMetadataStore:
     """Test metadata caching and invalidation."""
 
@@ -196,6 +200,7 @@ class TestMetadataStore:
         assert set(by_location1.keys()) == set(by_location2.keys())
 
 
+@pytest.mark.emulator
 class TestOrganizeEdgeCases:
     """Test edge cases in organization methods."""
 

--- a/tests/test_network/test_concurrent_requests.py
+++ b/tests/test_network/test_concurrent_requests.py
@@ -30,6 +30,7 @@ class TestConcurrentRequests:
             await conn.request(Device.GetPower(), timeout=0.1)
 
 
+@pytest.mark.emulator
 class TestErrorHandling:
     """Test error handling in concurrent scenarios using DeviceConnection."""
 
@@ -112,6 +113,7 @@ class TestErrorHandling:
         assert results[1] == "label_success"
 
 
+@pytest.mark.emulator
 class TestAsyncGeneratorRequests:
     """Test async generator-based request streaming."""
 
@@ -199,6 +201,7 @@ class TestAsyncGeneratorRequests:
             await conn.close()
 
 
+@pytest.mark.emulator
 class TestRetryTimeoutBudget:
     """Test that retry sleep time doesn't consume the timeout budget.
 

--- a/tests/test_network/test_connection.py
+++ b/tests/test_network/test_connection.py
@@ -227,6 +227,7 @@ class TestDeviceConnection:
         assert not conn.is_open
 
 
+@pytest.mark.emulator
 class TestAsyncGeneratorStreaming:
     """Test async generator streaming functionality."""
 

--- a/tests/test_network/test_discovery_errors.py
+++ b/tests/test_network/test_discovery_errors.py
@@ -46,6 +46,7 @@ class TestParseDeviceStateServiceErrors:
         assert port == 56700
 
 
+@pytest.mark.emulator
 class TestDiscoveryMalformedPackets:
     """Test discovery handling of malformed packets."""
 
@@ -90,6 +91,7 @@ class TestDiscoveryWithEmulatorErrors:
         assert count == 0
 
 
+@pytest.mark.emulator
 class TestDiscoveryDeduplication:
     """Test that discovered devices are properly deduplicated."""
 

--- a/tests/test_theme/test_apply_theme.py
+++ b/tests/test_theme/test_apply_theme.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from lifx.api import DeviceGroup
 from lifx.color import HSBK, Colors
 from lifx.devices.matrix import MatrixLight
@@ -11,6 +13,7 @@ from lifx.devices.multizone import MultiZoneLight
 from lifx.theme import Theme
 
 
+@pytest.mark.emulator
 class TestLightApplyTheme:
     """Tests for Light.apply_theme method."""
 


### PR DESCRIPTION
- Add @pytest.mark.emulator to all test classes using emulator fixtures
- Update emulator_available fixture to return False on macOS/Windows
- Fix cleanup_device_connections fixture to be conditional on emulator
- Register 'emulator' marker in pyproject.toml to avoid warnings
- Update CI workflow to only upload coverage to Codecov on Ubuntu

This is to remove the overhead and delay of running the emulator on macOS and Windows via GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)