### PR TITLE
test(ci): migrate from subprocess to lifx-emulator-core library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ structures from a YAML specification.
 **Python Versions**: 3.11, 3.12, 3.13, 3.14 (tested on all versions via CI)
 **Runtime Dependencies**: Zero - completely dependency-free!
 **Async Framework**: Python's built-in `asyncio` (no external async library required)
-**Test Isolation**: lifx-emulator runs as subprocess, not a dependency
+**Test Isolation**: lifx-emulator-core runs embedded in-process for fast, cross-platform testing
 
 ## Essential Commands
 
@@ -610,38 +610,27 @@ The `discover_devices()` function implements DoS protection through:
 Test files mirror source structure: `tests/test_devices/test_light.py` tests
 `src/lifx/devices/light.py`
 
-### Integration Tests with lifx-emulator
+### Integration Tests with lifx-emulator-core
 
-Some tests require the `lifx-emulator` to run integration tests against real protocol implementations.
-The emulator runs as a **separate subprocess** and is **not** a dependency of lifx.
+Some tests require `lifx-emulator-core` to run integration tests against real protocol implementations.
+The emulator runs **embedded in-process** as a dev dependency, providing:
+- Fast startup (~5-10ms vs 500ms+ for subprocess)
+- Cross-platform support (Windows, macOS, Linux)
+- Direct access to emulator internals for scenario testing
 
-**Setup Options**:
-
-1. **Development setup** (recommended): Clone lifx-emulator as a sibling directory
-   ```bash
-   cd ..
-   git clone https://github.com/Djelibeybi/lifx-emulator.git
-   cd lifx-emulator
-   uv sync
-   cd ../lifx
-   ```
-
-2. **System install**: Install lifx-emulator globally (requires Python 3.13+)
-   ```bash
-   uv tool install lifx-emulator
-   ```
+**Setup**: The emulator is automatically installed as a dev dependency:
+```bash
+uv sync  # Installs lifx-emulator-core automatically
+```
 
 **Running Integration Tests**:
+- Tests marked with `@pytest.mark.emulator` use the embedded emulator
 - If emulator is not available, these tests are automatically skipped
-- No code changes needed - pytest plugin handles everything
-- **Works on all Python versions (3.11+)** since emulator runs as separate process
-
-**Note**: The emulator itself requires Python 3.13+, but it runs as a subprocess so your
-lifx tests can run on any supported Python version (3.11-3.14).
+- **Works on all Python versions (3.11+)**
 
 **External Emulator Management**:
 
-For cases where you want to manage the emulator separately (or test against actual hardware), you can skip the automatic emulator subprocess startup:
+For cases where you want to manage the emulator separately (or test against actual hardware):
 
 ```bash
 # Use an externally managed emulator instance
@@ -654,7 +643,6 @@ LIFX_EMULATOR_EXTERNAL=1 pytest
 This is useful when:
 - Testing against actual LIFX hardware on your network
 - Running the emulator with custom configuration or device setup
-- Using a shared emulator instance across multiple test runs
 - Debugging emulator behavior separately from the test suite
 
 **Key Test Files:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 [dependency-groups]
 dev = [
     "hatchling>=1.27.0",
-    "lifx-emulator>=2.4.0",
+    "lifx-emulator-core>=3.0.3",
     "mkdocs-git-revision-date-localized-plugin>=1.4.7",
     "mkdocs-llmstxt>=0.4.0",
     "mkdocs-material>=9.6.22",
@@ -41,7 +41,6 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=7.0.0",
     "pytest-sugar>=1.1.1",
-    "pytest-xprocess>=1.0.2",
     "pyyaml>=6.0.3",
     "ruff>=0.14.2",
 ]
@@ -103,7 +102,7 @@ addopts = """\
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
-    "emulator: tests that require the lifx-emulator (only run on Linux)",
+    "emulator: tests that require the lifx-emulator-core embedded emulator",
 ]
 
 [tool.coverage.run]

--- a/tests/test_api/test_api_apply_theme.py
+++ b/tests/test_api/test_api_apply_theme.py
@@ -259,8 +259,6 @@ class TestDeviceGroupApplyTheme:
         self, emulator_devices: DeviceGroup
     ) -> None:
         """Test apply_theme with zero duration (instant change)."""
-        import rich
-
         group = emulator_devices
 
         async with group:
@@ -271,7 +269,6 @@ class TestDeviceGroupApplyTheme:
             await asyncio.sleep(0.05)
             device = group.lights[0]
             color, _, _ = await device.get_color()
-            rich.inspect(color, methods=True, dunder=True)
             assert color in theme.colors
 
     async def test_apply_theme_large_duration(

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -19,6 +19,10 @@ class TestHSBK:
         assert color.saturation == 0.5
         assert color.brightness == 0.75
         assert color.kelvin == 3500
+        assert repr(color) == (
+            f"HSBK(hue={color.hue}, saturation={color.saturation:.2f}, "
+            f"brightness={color.brightness:.2f}, kelvin={color.kelvin})"
+        )
 
     def test_validate_hue_range(self) -> None:
         """Test hue validation."""

--- a/tests/test_devices/test_base.py
+++ b/tests/test_devices/test_base.py
@@ -48,9 +48,9 @@ class TestDevice:
             Device(serial="d073d5", ip="192.168.1.100")
 
     @pytest.mark.asyncio
-    async def test_create_device_from_ip(self, emulator_server: int) -> None:
+    async def test_create_device_from_ip(self, emulator_port: int) -> None:
         """Test creating a device from an IP address."""
-        async with await Device.from_ip(ip="127.0.0.1", port=emulator_server) as device:
+        async with await Device.from_ip(ip="127.0.0.1", port=emulator_port) as device:
             assert isinstance(device, Device)
 
     async def test_get_label(self, device: Device) -> None:
@@ -296,10 +296,12 @@ class TestLocationAndGroupManagement:
         # Replace device's connection with mock
 
         # Mock discovery to return no devices (so new UUID is generated)
-        with patch(
-            "lifx.network.discovery.discover_devices", new_callable=AsyncMock
-        ) as mock_discover:
-            mock_discover.return_value = []
+        # Use a proper async generator mock since discover_devices is an async generator
+        async def empty_async_gen(*args, **kwargs):
+            return
+            yield  # Makes this an async generator
+
+        with patch("lifx.network.discovery.discover_devices", empty_async_gen):
             await device.set_location(label)
 
         # Verify request was called with new connection API
@@ -326,10 +328,12 @@ class TestLocationAndGroupManagement:
         # Replace device's connection with mock
 
         # Mock discovery to return no devices (so new UUID is generated)
-        with patch(
-            "lifx.network.discovery.discover_devices", new_callable=AsyncMock
-        ) as mock_discover:
-            mock_discover.return_value = []
+        # Use a proper async generator mock since discover_devices is an async generator
+        async def empty_async_gen(*args, **kwargs):
+            return
+            yield  # Makes this an async generator
+
+        with patch("lifx.network.discovery.discover_devices", empty_async_gen):
             await device.set_group(label)
 
         # Verify request was called with new connection API
@@ -362,10 +366,12 @@ class TestLocationAndGroupManagement:
         device2.connection = mock_conn
 
         # Mock discovery to return no devices for both calls
-        with patch(
-            "lifx.network.discovery.discover_devices", new_callable=AsyncMock
-        ) as mock_discover:
-            mock_discover.return_value = []
+        # Use a proper async generator mock since discover_devices is an async generator
+        async def empty_async_gen(*args, **kwargs):
+            return
+            yield  # Makes this an async generator
+
+        with patch("lifx.network.discovery.discover_devices", empty_async_gen):
             await device1.set_location(label)
             mock_conn.request.reset_mock()
             await device2.set_location(label)
@@ -389,10 +395,12 @@ class TestLocationAndGroupManagement:
         device2.connection = mock_conn
 
         # Mock discovery to return no devices for both calls
-        with patch(
-            "lifx.network.discovery.discover_devices", new_callable=AsyncMock
-        ) as mock_discover:
-            mock_discover.return_value = []
+        # Use a proper async generator mock since discover_devices is an async generator
+        async def empty_async_gen(*args, **kwargs):
+            return
+            yield  # Makes this an async generator
+
+        with patch("lifx.network.discovery.discover_devices", empty_async_gen):
             await device1.set_group(label)
             mock_conn.request.reset_mock()
             await device2.set_group(label)

--- a/tests/test_network/test_discovery_devices.py
+++ b/tests/test_network/test_discovery_devices.py
@@ -25,15 +25,13 @@ class TestDiscoveredDeviceCreateDevice:
     """
 
     @pytest.mark.asyncio
-    async def test_create_device_returns_correct_type(
-        self, emulator_server: int
-    ) -> None:
+    async def test_create_device_returns_correct_type(self, emulator_port: int) -> None:
         """Test that create_device returns a device instance."""
         first_disc = None
         async for disc in discover_devices(
             timeout=2.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             first_disc = disc
             break
@@ -52,14 +50,14 @@ class TestDiscoveredDeviceCreateDevice:
 
     @pytest.mark.asyncio
     async def test_create_device_preserves_connection_info(
-        self, emulator_server: int
+        self, emulator_port: int
     ) -> None:
         """Test that create_device preserves serial, IP, and port info."""
         first_disc = None
         async for disc in discover_devices(
             timeout=2.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             first_disc = disc
             break
@@ -74,9 +72,7 @@ class TestDiscoveredDeviceCreateDevice:
         assert device.port == first_disc.port
 
     @pytest.mark.asyncio
-    async def test_create_device_all_emulator_devices(
-        self, emulator_server: int
-    ) -> None:
+    async def test_create_device_all_emulator_devices(self, emulator_port: int) -> None:
         """Test create_device works for all device types in emulator.
 
         The emulator creates 7 devices:
@@ -92,7 +88,7 @@ class TestDiscoveredDeviceCreateDevice:
         async for disc in discover_devices(
             timeout=2.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             device = await disc.create_device()
             if device is not None:
@@ -114,7 +110,7 @@ class TestDiscoveryEdgeCasesWithEmulator:
 
     @pytest.mark.asyncio
     async def test_discover_devices_with_multiple_simultaneous_creates(
-        self, emulator_server: int
+        self, emulator_port: int
     ) -> None:
         """Test creating multiple device instances simultaneously.
 
@@ -127,7 +123,7 @@ class TestDiscoveryEdgeCasesWithEmulator:
         async for disc in discover_devices(
             timeout=2.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             discovered_list.append(disc)
             if len(discovered_list) >= 2:
@@ -144,14 +140,14 @@ class TestDiscoveryEdgeCasesWithEmulator:
 
     @pytest.mark.asyncio
     async def test_discover_devices_response_time_accuracy(
-        self, emulator_server: int
+        self, emulator_port: int
     ) -> None:
         """Test that response_time is accurately calculated."""
         devices = []
         async for disc in discover_devices(
             timeout=1.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             devices.append(disc)
             if len(devices) >= 2:
@@ -168,14 +164,14 @@ class TestDiscoveryEdgeCasesWithEmulator:
 
     @pytest.mark.asyncio
     async def test_discover_all_devices_have_valid_ports(
-        self, emulator_server: int
+        self, emulator_port: int
     ) -> None:
         """Test that all discovered devices have valid port numbers."""
         devices = []
         async for disc in discover_devices(
             timeout=1.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             devices.append(disc)
             if len(devices) >= 2:

--- a/tests/test_network/test_discovery_errors.py
+++ b/tests/test_network/test_discovery_errors.py
@@ -51,7 +51,7 @@ class TestDiscoveryMalformedPackets:
     """Test discovery handling of malformed packets."""
 
     @pytest.mark.asyncio
-    async def test_discovery_with_malformed_header(self, emulator_server: int) -> None:
+    async def test_discovery_with_malformed_header(self, emulator_port: int) -> None:
         """Test discovery continues when receiving malformed packets.
 
         The discovery should skip malformed responses and continue waiting
@@ -63,7 +63,7 @@ class TestDiscoveryMalformedPackets:
         async for disc in discover_devices(
             timeout=2.0,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             found_device = True
             break
@@ -96,13 +96,13 @@ class TestDiscoveryDeduplication:
     """Test that discovered devices are properly deduplicated."""
 
     @pytest.mark.asyncio
-    async def test_devices_deduplicated_by_serial(self, emulator_server: int) -> None:
+    async def test_devices_deduplicated_by_serial(self, emulator_port: int) -> None:
         """Test that duplicate responses are deduplicated by serial."""
         seen_serials: set[str] = set()
         async for disc in discover_devices(
             timeout=1.5,
             broadcast_address="127.0.0.1",
-            port=emulator_server,
+            port=emulator_port,
         ):
             # Each yielded device should have a unique serial
             assert disc.serial not in seen_serials, f"Duplicate serial: {disc.serial}"

--- a/uv.lock
+++ b/uv.lock
@@ -9,44 +9,12 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/a6/dc46877b911e40c00d395771ea710d5e77b6de7bacd5fdcd78d70cc5a48f/annotated_doc-0.0.3.tar.gz", hash = "sha256:e18370014c70187422c33e945053ff4c286f453a984eba84d0dbfa0c935adeda", size = 5535, upload-time = "2025-10-24T14:57:10.718Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/b7/cf592cb5de5cb3bade3357f8d2cf42bf103bbe39f459824b4939fd212911/annotated_doc-0.0.3-py3-none-any.whl", hash = "sha256:348ec6664a76f1fd3be81f43dffbee4c7e8ce931ba71ec67cc7f4ade7fbbb580", size = 5488, upload-time = "2025-10-24T14:57:09.462Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
-]
-
-[[package]]
-name = "attrs"
-version = "25.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
@@ -281,54 +249,6 @@ toml = [
 ]
 
 [[package]]
-name = "cyclopts"
-version = "4.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "docstring-parser" },
-    { name = "rich" },
-    { name = "rich-rst" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/51/a67b17fac2530d22216a335bd10f48631412dd824013ea559ec236668f76/cyclopts-4.2.1.tar.gz", hash = "sha256:49bb4c35644e7a9658f706ade4cf1a9958834b2dca4425e2fafecf8a0537fac7", size = 148693, upload-time = "2025-10-31T14:30:58.681Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/1d/2b313e157c9c7bba319e42f464d15073d32a81ac4827bdc5b7de38832b3e/cyclopts-4.2.1-py3-none-any.whl", hash = "sha256:17a801faa814988b0307385ef8aaeb6b14b4d64473015a2d66bde9ea13f14d9c", size = 184333, upload-time = "2025-10-31T14:30:57.581Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
-
-[[package]]
-name = "docutils"
-version = "0.22.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/02/111134bfeb6e6c7ac4c74594e39a59f6c0195dc4846afbeac3cba60f1927/docutils-0.22.3.tar.gz", hash = "sha256:21486ae730e4ca9f622677b1412b879af1791efcfba517e4c6f60be543fc8cdd", size = 2290153, upload-time = "2025-11-06T02:35:55.655Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/a8/c6a4b901d17399c77cd81fb001ce8961e9f5e04d3daf27e8925cb012e163/docutils-0.22.3-py3-none-any.whl", hash = "sha256:bd772e4aca73aff037958d44f2be5229ded4c09927fcf8690c577b66234d6ceb", size = 633032, upload-time = "2025-11-06T02:35:52.391Z" },
-]
-
-[[package]]
-name = "fastapi"
-version = "0.121.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/77a2df0946703973b9905fd0cde6172c15e0781984320123b4f5079e7113/fastapi-0.121.0.tar.gz", hash = "sha256:06663356a0b1ee93e875bbf05a31fb22314f5bed455afaaad2b2dad7f26e98fa", size = 342412, upload-time = "2025-11-03T10:25:54.818Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/2c/42277afc1ba1a18f8358561eee40785d27becab8f80a1f945c0a3051c6eb/fastapi-0.121.0-py3-none-any.whl", hash = "sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106", size = 109183, upload-time = "2025-11-03T10:25:53.27Z" },
-]
-
-[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -374,15 +294,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/6c09dd7ce4c7837e4cdb11dce980cb45ae3cd87677298dc3b781b6bce7d3/griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13", size = 424684, upload-time = "2025-09-05T15:02:29.167Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/b1/9ff6578d789a89812ff21e4e0f80ffae20a65d5dd84e7a17873fe3b365be/griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0", size = 144439, upload-time = "2025-09-05T15:02:27.511Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -438,7 +349,7 @@ source = { editable = "." }
 [package.dev-dependencies]
 dev = [
     { name = "hatchling" },
-    { name = "lifx-emulator" },
+    { name = "lifx-emulator-core" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
@@ -448,7 +359,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-sugar" },
-    { name = "pytest-xprocess" },
     { name = "pyyaml" },
     { name = "ruff" },
 ]
@@ -458,7 +368,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "hatchling", specifier = ">=1.27.0" },
-    { name = "lifx-emulator", specifier = ">=2.4.0" },
+    { name = "lifx-emulator-core", specifier = ">=3.0.3" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
     { name = "mkdocs-llmstxt", specifier = ">=0.4.0" },
     { name = "mkdocs-material", specifier = ">=9.6.22" },
@@ -468,25 +378,21 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
-    { name = "pytest-xprocess", specifier = ">=1.0.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", specifier = ">=0.14.2" },
 ]
 
 [[package]]
-name = "lifx-emulator"
-version = "2.4.0"
+name = "lifx-emulator-core"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cyclopts" },
-    { name = "fastapi" },
+    { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "rich" },
-    { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/2f/e71fc3431524ea25d2457ec63a8e9c792e4ba96c6d4509ef69183c074c2c/lifx_emulator-2.4.0.tar.gz", hash = "sha256:36ad7fa7e0ce9491e4bb377debebf8af46454baec54d62cd5e55d8b753b79f66", size = 352495, upload-time = "2025-11-19T14:56:21.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/5f/f1426c076da3bba3cb140e70098e42952093174aa544edeb53d8a915be0f/lifx_emulator_core-3.0.3.tar.gz", hash = "sha256:bf029963544a5ef58c8d88e3836b795d24f0dfdd62b0503091718b71f3a4624f", size = 133262, upload-time = "2025-11-27T02:50:30.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/0d/a71224bfd5916cb38681face34611a7198bc2c7249bedcc099986f8e22d4/lifx_emulator-2.4.0-py3-none-any.whl", hash = "sha256:ebb310bf27e27de34cd3433cef31e6f083094254640d227e2bf7dc4c002b2ad8", size = 128474, upload-time = "2025-11-19T14:56:20.346Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/43/72acec4863f050c6e3445c911c7f16f42375c6a1f08cfdabfccade4d265a/lifx_emulator_core-3.0.3-py3-none-any.whl", hash = "sha256:f5169c3932dfc0fc44692d6238e5d5070e5929e8fc7b91d6b83abe65cb926c33", size = 102060, upload-time = "2025-11-27T02:50:29.111Z" },
 ]
 
 [[package]]
@@ -844,34 +750,8 @@ wheels = [
 ]
 
 [[package]]
-name = "psutil"
-version = "7.1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/88/bdd0a41e5857d5d703287598cbf08dad90aed56774ea52ae071bae9071b6/psutil-7.1.3.tar.gz", hash = "sha256:6c86281738d77335af7aec228328e944b30930899ea760ecf33a4dba66be5e74", size = 489059, upload-time = "2025-11-02T12:25:54.619Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/93/0c49e776b8734fef56ec9c5c57f923922f2cf0497d62e0f419465f28f3d0/psutil-7.1.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0005da714eee687b4b8decd3d6cc7c6db36215c9e74e5ad2264b90c3df7d92dc", size = 239751, upload-time = "2025-11-02T12:25:58.161Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/8d/b31e39c769e70780f007969815195a55c81a63efebdd4dbe9e7a113adb2f/psutil-7.1.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:19644c85dcb987e35eeeaefdc3915d059dac7bd1167cdcdbf27e0ce2df0c08c0", size = 240368, upload-time = "2025-11-02T12:26:00.491Z" },
-    { url = "https://files.pythonhosted.org/packages/62/61/23fd4acc3c9eebbf6b6c78bcd89e5d020cfde4acf0a9233e9d4e3fa698b4/psutil-7.1.3-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95ef04cf2e5ba0ab9eaafc4a11eaae91b44f4ef5541acd2ee91d9108d00d59a7", size = 287134, upload-time = "2025-11-02T12:26:02.613Z" },
-    { url = "https://files.pythonhosted.org/packages/30/1c/f921a009ea9ceb51aa355cb0cc118f68d354db36eae18174bab63affb3e6/psutil-7.1.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1068c303be3a72f8e18e412c5b2a8f6d31750fb152f9cb106b54090296c9d251", size = 289904, upload-time = "2025-11-02T12:26:05.207Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/82/62d68066e13e46a5116df187d319d1724b3f437ddd0f958756fc052677f4/psutil-7.1.3-cp313-cp313t-win_amd64.whl", hash = "sha256:18349c5c24b06ac5612c0428ec2a0331c26443d259e2a0144a9b24b4395b58fa", size = 249642, upload-time = "2025-11-02T12:26:07.447Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ad/c1cd5fe965c14a0392112f68362cfceb5230819dbb5b1888950d18a11d9f/psutil-7.1.3-cp313-cp313t-win_arm64.whl", hash = "sha256:c525ffa774fe4496282fb0b1187725793de3e7c6b29e41562733cae9ada151ee", size = 245518, upload-time = "2025-11-02T12:26:09.719Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/bb/6670bded3e3236eb4287c7bcdc167e9fae6e1e9286e437f7111caed2f909/psutil-7.1.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b403da1df4d6d43973dc004d19cee3b848e998ae3154cc8097d139b77156c353", size = 239843, upload-time = "2025-11-02T12:26:11.968Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/66/853d50e75a38c9a7370ddbeefabdd3d3116b9c31ef94dc92c6729bc36bec/psutil-7.1.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ad81425efc5e75da3f39b3e636293360ad8d0b49bed7df824c79764fb4ba9b8b", size = 240369, upload-time = "2025-11-02T12:26:14.358Z" },
-    { url = "https://files.pythonhosted.org/packages/41/bd/313aba97cb5bfb26916dc29cf0646cbe4dd6a89ca69e8c6edce654876d39/psutil-7.1.3-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f33a3702e167783a9213db10ad29650ebf383946e91bc77f28a5eb083496bc9", size = 288210, upload-time = "2025-11-02T12:26:16.699Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/fa/76e3c06e760927a0cfb5705eb38164254de34e9bd86db656d4dbaa228b04/psutil-7.1.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fac9cd332c67f4422504297889da5ab7e05fd11e3c4392140f7370f4208ded1f", size = 291182, upload-time = "2025-11-02T12:26:18.848Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/1d/5774a91607035ee5078b8fd747686ebec28a962f178712de100d00b78a32/psutil-7.1.3-cp314-cp314t-win_amd64.whl", hash = "sha256:3792983e23b69843aea49c8f5b8f115572c5ab64c153bada5270086a2123c7e7", size = 250466, upload-time = "2025-11-02T12:26:21.183Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/e426584bacb43a5cb1ac91fae1937f478cd8fbe5e4ff96574e698a2c77cd/psutil-7.1.3-cp314-cp314t-win_arm64.whl", hash = "sha256:31d77fcedb7529f27bb3a0472bea9334349f9a04160e8e6e5020f22c59893264", size = 245756, upload-time = "2025-11-02T12:26:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/94/46b9154a800253e7ecff5aaacdf8ebf43db99de4a2dfa18575b02548654e/psutil-7.1.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2bdbcd0e58ca14996a42adf3621a6244f1bb2e2e528886959c72cf1e326677ab", size = 238359, upload-time = "2025-11-02T12:26:25.284Z" },
-    { url = "https://files.pythonhosted.org/packages/68/3a/9f93cff5c025029a36d9a92fef47220ab4692ee7f2be0fba9f92813d0cb8/psutil-7.1.3-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc31fa00f1fbc3c3802141eede66f3a2d51d89716a194bf2cd6fc68310a19880", size = 239171, upload-time = "2025-11-02T12:26:27.23Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b1/5f49af514f76431ba4eea935b8ad3725cdeb397e9245ab919dbc1d1dc20f/psutil-7.1.3-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb428f9f05c1225a558f53e30ccbad9930b11c3fc206836242de1091d3e7dd3", size = 263261, upload-time = "2025-11-02T12:26:29.48Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
-]
-
-[[package]]
 name = "pydantic"
-version = "2.12.4"
+version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -879,9 +759,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/ad/a17bc283d7d81837c061c49e3eaa27a45991759a1b7eae1031921c6bd924/pydantic-2.12.4.tar.gz", hash = "sha256:0f8cb9555000a4b5b617f66bfd2566264c4984b27589d3b845685983e8ea85ac", size = 821038, upload-time = "2025-11-05T10:50:08.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/2f/e68750da9b04856e2a7ec56fc6f034a5a79775e9b9a81882252789873798/pydantic-2.12.4-py3-none-any.whl", hash = "sha256:92d3d202a745d46f9be6df459ac5a064fdaa3c1c4cd8adcfa332ccf3c05f871e", size = 463400, upload-time = "2025-11-05T10:50:06.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
 [[package]]
@@ -1073,19 +953,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-xprocess"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "psutil" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/27/6f/e53d349445b4280f6b47bbed87127e994f331c335377d5e72407b376ad46/pytest-xprocess-1.0.2.tar.gz", hash = "sha256:15e270637586eabc56755ee5fcc81c48bdb46ba7ef7c0d5b1b64302d080cc60f", size = 13232, upload-time = "2024-05-19T16:12:21.819Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/cf/91b94238c843bfbae0a6674df45015aa3908b91454c496b2eb29e7991255/pytest_xprocess-1.0.2-py3-none-any.whl", hash = "sha256:0b0444d1f789fd9b4ba8b6b38b1d0139f226ab14091db2698a0521c1770523dd", size = 9628, upload-time = "2024-05-19T16:12:19.773Z" },
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1189,32 +1056,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
-]
-
-[[package]]
-name = "rich-rst"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1259,34 +1100,12 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
-]
-
-[[package]]
-name = "starlette"
-version = "0.49.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
 ]
 
 [[package]]
@@ -1384,19 +1203,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
-]
-
-[[package]]
-name = "uvicorn"
-version = "0.38.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the external lifx-emulator subprocess with embedded lifx-emulator-core library for faster, more reliable, and cross-platform test execution.

Key changes:
  - Use lifx-emulator-core as direct dependency instead of subprocess management
  - Replace pytest-xprocess with EmulatorRunner using background thread
  - Update emulator_server fixture to return (port, server, scenario_manager) tuple
  - Add scenario management fixtures for test isolation
  - Fix ResourceWarning leaks by adding proper cleanup to tests that create fake Light devices (test_api_batch_errors.py, test_concurrent_requests.py)
  - Fix RuntimeWarning from async generator mocking in test_base.py
  - Update CLAUDE.md documentation for new emulator architecture

Benefits:
  - Faster startup (~5-10ms vs 500ms+)
  - Cross-platform support (no longer Linux-only)
  - In-process scenario management for better test isolation
  - Reduced test warnings from 44 to 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)