### PR TITLE
feat(devices): add CeilingLight with up/downlight component control

### DIFF
--- a/src/lifx/devices/__init__.py
+++ b/src/lifx/devices/__init__.py
@@ -10,6 +10,7 @@ from lifx.devices.base import (
     FirmwareInfo,
     WifiInfo,
 )
+from lifx.devices.ceiling import CeilingLight
 from lifx.devices.hev import HevLight, HevLightState
 from lifx.devices.infrared import InfraredLight, InfraredLightState
 from lifx.devices.light import Light, LightState
@@ -17,6 +18,7 @@ from lifx.devices.matrix import MatrixEffect, MatrixLight, MatrixLightState, Til
 from lifx.devices.multizone import MultiZoneEffect, MultiZoneLight, MultiZoneLightState
 
 __all__ = [
+    "CeilingLight",
     "CollectionInfo",
     "Device",
     "DeviceInfo",

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -1,0 +1,784 @@
+"""LIFX Ceiling Light Device.
+
+This module provides the CeilingLight class for controlling LIFX Ceiling lights with
+independent uplight and downlight component control.
+
+Terminology:
+- Zone: Individual HSBK pixel in the matrix (indexed 0-63 or 0-127)
+- Component: Logical grouping of zones:
+  - Uplight Component: Single zone for ambient lighting (zone 63 or 127)
+  - Downlight Component: Multiple zones for main illumination (zones 0-62 or 0-126)
+
+Product IDs:
+- 176: Ceiling (US) - 8x8 matrix
+- 177: Ceiling (Intl) - 8x8 matrix
+- 201: Ceiling Capsule (US) - 16x8 matrix
+- 202: Ceiling Capsule (Intl) - 16x8 matrix
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lifx.color import HSBK
+from lifx.devices.matrix import MatrixLight
+from lifx.exceptions import LifxError
+from lifx.products import get_ceiling_layout, is_ceiling_product
+
+if TYPE_CHECKING:
+    pass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CeilingLight(MatrixLight):
+    """LIFX Ceiling Light with independent uplight and downlight control.
+
+    CeilingLight extends MatrixLight to provide semantic control over uplight and
+    downlight components while maintaining full backward compatibility with the
+    MatrixLight API.
+
+    The uplight component is the last zone in the matrix, and the downlight component
+    consists of all other zones.
+
+    Example:
+        ```python
+        from lifx.devices import CeilingLight
+        from lifx.color import HSBK
+
+        async with await CeilingLight.from_ip("192.168.1.100") as ceiling:
+            # Independent component control
+            await ceiling.set_downlight_colors(HSBK(hue=0, sat=0, bri=1.0, kelvin=3500))
+            await ceiling.set_uplight_color(HSBK(hue=30, sat=0.2, bri=0.3, kelvin=2700))
+
+            # Turn components on/off
+            await ceiling.turn_downlight_on()
+            await ceiling.turn_uplight_off()
+
+            # Check component state
+            if ceiling.uplight_is_on:
+                print("Uplight is on")
+        ```
+    """
+
+    def __init__(
+        self,
+        serial: str,
+        ip: str,
+        port: int = 56700,  # LIFX_UDP_PORT
+        timeout: float = 0.5,  # DEFAULT_REQUEST_TIMEOUT
+        max_retries: int = 3,  # DEFAULT_MAX_RETRIES
+        state_file: str | None = None,
+    ):
+        """Initialize CeilingLight.
+
+        Args:
+            serial: Device serial number
+            ip: Device IP address
+            port: Device UDP port (default: 56700)
+            timeout: Overall timeout for network requests in seconds
+                (default: 0.5)
+            max_retries: Maximum number of retry attempts for network requests
+                (default: 3)
+            state_file: Optional path to JSON file for state persistence
+
+        Raises:
+            LifxError: If device is not a supported Ceiling product
+        """
+        super().__init__(serial, ip, port, timeout, max_retries)
+        self._state_file = state_file
+        self._stored_uplight_state: HSBK | None = None
+        self._stored_downlight_state: list[HSBK] | None = None
+        self._last_uplight_color: HSBK | None = None
+        self._last_downlight_colors: list[HSBK] | None = None
+
+    async def __aenter__(self) -> CeilingLight:
+        """Async context manager entry."""
+        await super().__aenter__()
+
+        # Validate product ID after version is fetched
+        if self.version and not is_ceiling_product(self.version.product):
+            raise LifxError(
+                f"Product ID {self.version.product} is not a supported Ceiling light."
+            )
+
+        # Load state from disk if state_file is provided
+        if self._state_file:
+            self._load_state_from_file()
+
+        return self
+
+    @classmethod
+    async def from_ip(
+        cls,
+        ip: str,
+        port: int = 56700,  # LIFX_UDP_PORT
+        serial: str | None = None,
+        timeout: float = 0.5,  # DEFAULT_REQUEST_TIMEOUT
+        max_retries: int = 3,  # DEFAULT_MAX_RETRIES
+        *,
+        state_file: str | None = None,
+    ) -> CeilingLight:
+        """Create CeilingLight from IP address.
+
+        Args:
+            ip: Device IP address
+            port: Port number (default LIFX_UDP_PORT)
+            serial: Serial number as 12-digit hex string
+            timeout: Request timeout for this device instance
+            max_retries: Maximum number of retries for requests
+            state_file: Optional path to JSON file for state persistence
+
+        Returns:
+            CeilingLight instance
+
+        Raises:
+            LifxDeviceNotFoundError: Device not found at IP
+            LifxTimeoutError: Device did not respond
+            LifxError: Device is not a supported Ceiling product
+        """
+        # Use parent class factory method
+        device = await super().from_ip(ip, port, serial, timeout, max_retries)
+        # Type cast to CeilingLight and set state_file
+        ceiling = CeilingLight(device.serial, device.ip)
+        ceiling._state_file = state_file
+        ceiling.connection = device.connection
+        return ceiling
+
+    @property
+    def uplight_zone(self) -> int:
+        """Zone index of the uplight component.
+
+        Returns:
+            Zone index (63 for standard Ceiling, 127 for Capsule)
+
+        Raises:
+            LifxError: If device version is not available or not a Ceiling product
+        """
+        if not self.version:
+            raise LifxError("Device version not available. Use async context manager.")
+
+        layout = get_ceiling_layout(self.version.product)
+        if not layout:
+            raise LifxError(f"Product ID {self.version.product} is not a Ceiling light")
+
+        return layout.uplight_zone
+
+    @property
+    def downlight_zones(self) -> slice:
+        """Slice representing the downlight component zones.
+
+        Returns:
+            Slice object (slice(0, 63) for standard, slice(0, 127) for Capsule)
+
+        Raises:
+            LifxError: If device version is not available or not a Ceiling product
+        """
+        if not self.version:
+            raise LifxError("Device version not available. Use async context manager.")
+
+        layout = get_ceiling_layout(self.version.product)
+        if not layout:
+            raise LifxError(f"Product ID {self.version.product} is not a Ceiling light")
+
+        return layout.downlight_zones
+
+    @property
+    def uplight_is_on(self) -> bool:
+        """True if uplight component is currently on.
+
+        Calculated as: power_level > 0 AND uplight brightness > 0
+
+        Note:
+            Requires recent data from device. Call get_uplight_color() or
+            get_power() to refresh cached values before checking this property.
+
+        Returns:
+            True if uplight component is on, False otherwise
+        """
+        if self._state is None or self._state.power == 0:
+            return False
+
+        if self._last_uplight_color is None:
+            return False
+
+        return self._last_uplight_color.brightness > 0
+
+    @property
+    def downlight_is_on(self) -> bool:
+        """True if downlight component is currently on.
+
+        Calculated as: power_level > 0 AND NOT all downlight zones have brightness == 0
+
+        Note:
+            Requires recent data from device. Call get_downlight_colors() or
+            get_power() to refresh cached values before checking this property.
+
+        Returns:
+            True if downlight component is on, False otherwise
+        """
+        if self._state is None or self._state.power == 0:
+            return False
+
+        if self._last_downlight_colors is None:
+            return False
+
+        # Downlight is on if any downlight zone has a brightness > 0
+        return any(c.brightness > 0 for c in self._last_downlight_colors)
+
+    async def get_uplight_color(self) -> HSBK:
+        """Get current uplight component color from device.
+
+        Returns:
+            HSBK color of uplight zone
+
+        Raises:
+            LifxTimeoutError: Device did not respond
+        """
+        # Get all colors from tile
+        all_colors = await self.get_all_tile_colors()
+        tile_colors = all_colors[0]  # First tile
+
+        # Extract uplight zone
+        uplight_color = tile_colors[self.uplight_zone]
+
+        # Cache for is_on property
+        self._last_uplight_color = uplight_color
+
+        return uplight_color
+
+    async def get_downlight_colors(self) -> list[HSBK]:
+        """Get current downlight component colors from device.
+
+        Returns:
+            List of HSBK colors for each downlight zone (63 or 127 zones)
+
+        Raises:
+            LifxTimeoutError: Device did not respond
+        """
+        # Get all colors from tile
+        all_colors = await self.get_all_tile_colors()
+        tile_colors = all_colors[0]  # First tile
+
+        # Extract downlight zones
+        downlight_colors = tile_colors[self.downlight_zones]
+
+        # Cache for is_on property
+        self._last_downlight_colors = downlight_colors
+
+        return downlight_colors
+
+    async def set_uplight_color(self, color: HSBK, duration: float = 0.0) -> None:
+        """Set uplight component color.
+
+        Args:
+            color: HSBK color to set
+            duration: Transition duration in seconds (default 0.0)
+
+        Raises:
+            ValueError: If color.brightness == 0 (use turn_uplight_off instead)
+            LifxTimeoutError: Device did not respond
+
+        Note:
+            Also updates stored state for future restoration.
+        """
+        if color.brightness == 0:
+            raise ValueError(
+                "Cannot set uplight color with brightness=0. "
+                "Use turn_uplight_off() instead."
+            )
+
+        # Get current colors for all zones
+        all_colors = await self.get_all_tile_colors()
+        tile_colors = all_colors[0]
+
+        # Update uplight zone
+        tile_colors[self.uplight_zone] = color
+
+        # Set all colors back (duration in milliseconds for set_matrix_colors)
+        await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
+
+        # Store state
+        self._stored_uplight_state = color
+        self._last_uplight_color = color
+
+        # Persist if enabled
+        if self._state_file:
+            self._save_state_to_file()
+
+    async def set_downlight_colors(
+        self, colors: HSBK | list[HSBK], duration: float = 0.0
+    ) -> None:
+        """Set downlight component colors.
+
+        Args:
+            colors: Either:
+                - Single HSBK: sets all downlight zones to same color
+                - List[HSBK]: sets each zone individually (must match zone count)
+            duration: Transition duration in seconds (default 0.0)
+
+        Raises:
+            ValueError: If any color.brightness == 0 (use turn_downlight_off instead)
+            ValueError: If list length doesn't match downlight zone count
+            LifxTimeoutError: Device did not respond
+
+        Note:
+            Also updates stored state for future restoration.
+        """
+        # Validate and normalize colors
+        if isinstance(colors, HSBK):
+            if colors.brightness == 0:
+                raise ValueError(
+                    "Cannot set downlight color with brightness=0. "
+                    "Use turn_downlight_off() instead."
+                )
+            downlight_colors = [colors] * len(range(*self.downlight_zones.indices(256)))
+        else:
+            if all(c.brightness == 0 for c in colors):
+                raise ValueError(
+                    "Cannot set downlight colors with brightness=0. "
+                    "Use turn_downlight_off() instead."
+                )
+
+            expected_count = len(range(*self.downlight_zones.indices(256)))
+            if len(colors) != expected_count:
+                raise ValueError(
+                    f"Expected {expected_count} colors for downlight, got {len(colors)}"
+                )
+            downlight_colors = colors
+
+        # Get current colors for all zones
+        all_colors = await self.get_all_tile_colors()
+        tile_colors = all_colors[0]
+
+        # Update downlight zones
+        tile_colors[self.downlight_zones] = downlight_colors
+
+        # Set all colors back
+        await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
+
+        # Store state
+        self._stored_downlight_state = downlight_colors
+        self._last_downlight_colors = downlight_colors
+
+        # Persist if enabled
+        if self._state_file:
+            self._save_state_to_file()
+
+    async def turn_uplight_on(
+        self, color: HSBK | None = None, duration: float = 0.0
+    ) -> None:
+        """Turn uplight component on.
+
+        Args:
+            color: Optional HSBK color. If provided:
+                - Uses this color immediately
+                - Updates stored state
+                If None, uses brightness determination logic
+            duration: Transition duration in seconds (default 0.0)
+
+        Raises:
+            ValueError: If color.brightness == 0
+            LifxTimeoutError: Device did not respond
+        """
+        if color is not None:
+            if color.brightness == 0:
+                raise ValueError("Cannot turn on uplight with brightness=0")
+            await self.set_uplight_color(color, duration)
+        else:
+            # Determine color using priority logic
+            determined_color = await self._determine_uplight_brightness()
+            await self.set_uplight_color(determined_color, duration)
+
+    async def turn_uplight_off(
+        self, color: HSBK | None = None, duration: float = 0.0
+    ) -> None:
+        """Turn uplight component off.
+
+        Args:
+            color: Optional HSBK color to store for future turn_on.
+                If provided, stores this color (with brightness=0 on the device).
+                If None, stores current color from device before turning off.
+            duration: Transition duration in seconds (default 0.0)
+
+        Raises:
+            ValueError: If color.brightness == 0
+            LifxTimeoutError: Device did not respond
+
+        Note:
+            Sets uplight zone brightness to 0 on device while preserving H, S, K.
+        """
+        if color is not None:
+            if color.brightness == 0:
+                raise ValueError(
+                    "Provided color cannot have brightness=0. "
+                    "Omit the parameter to use current color."
+                )
+            # Store the provided color
+            self._stored_uplight_state = color
+        else:
+            # Get and store current color
+            current_color = await self.get_uplight_color()
+            self._stored_uplight_state = current_color
+
+        # Create color with brightness=0 for device
+        off_color = HSBK(
+            hue=self._stored_uplight_state.hue,
+            saturation=self._stored_uplight_state.saturation,
+            brightness=0.0,
+            kelvin=self._stored_uplight_state.kelvin,
+        )
+
+        # Get all colors and update uplight zone
+        all_colors = await self.get_all_tile_colors()
+        tile_colors = all_colors[0]
+        tile_colors[self.uplight_zone] = off_color
+        await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
+
+        # Update cache
+        self._last_uplight_color = off_color
+
+        # Persist if enabled
+        if self._state_file:
+            self._save_state_to_file()
+
+    async def turn_downlight_on(
+        self, colors: HSBK | list[HSBK] | None = None, duration: float = 0.0
+    ) -> None:
+        """Turn downlight component on.
+
+        Args:
+            colors: Optional colors. Can be:
+                - None: uses brightness determination logic
+                - Single HSBK: sets all downlight zones to same color
+                - List[HSBK]: sets each zone individually (must match zone count)
+                If provided, updates stored state.
+            duration: Transition duration in seconds (default 0.0)
+
+        Raises:
+            ValueError: If any color.brightness == 0
+            ValueError: If list length doesn't match downlight zone count
+            LifxTimeoutError: Device did not respond
+        """
+        if colors is not None:
+            await self.set_downlight_colors(colors, duration)
+        else:
+            # Determine colors using priority logic
+            determined_colors = await self._determine_downlight_brightness()
+            await self.set_downlight_colors(determined_colors, duration)
+
+    async def turn_downlight_off(
+        self, colors: HSBK | list[HSBK] | None = None, duration: float = 0.0
+    ) -> None:
+        """Turn downlight component off.
+
+        Args:
+            colors: Optional colors to store for future turn_on. Can be:
+                - None: stores current colors from device
+                - Single HSBK: stores this color for all zones
+                - List[HSBK]: stores individual colors (must match zone count)
+                If provided, stores these colors (with brightness=0 on device).
+            duration: Transition duration in seconds (default 0.0)
+
+        Raises:
+            ValueError: If any color.brightness == 0
+            ValueError: If list length doesn't match downlight zone count
+            LifxTimeoutError: Device did not respond
+
+        Note:
+            Sets all downlight zone brightness to 0 on device while preserving H, S, K.
+        """
+        expected_count = len(range(*self.downlight_zones.indices(256)))
+
+        if colors is not None:
+            # Validate and normalize provided colors
+            if isinstance(colors, HSBK):
+                if colors.brightness == 0:
+                    raise ValueError(
+                        "Provided color cannot have brightness=0. "
+                        "Omit the parameter to use current colors."
+                    )
+                colors_to_store = [colors] * expected_count
+            else:
+                if all(c.brightness == 0 for c in colors):
+                    raise ValueError(
+                        "Provided colors cannot have brightness=0. "
+                        "Omit the parameter to use current colors."
+                    )
+                if len(colors) != expected_count:
+                    raise ValueError(
+                        f"Expected {expected_count} colors for downlight, "
+                        f"got {len(colors)}"
+                    )
+                colors_to_store = colors
+
+            self._stored_downlight_state = colors_to_store
+        else:
+            # Get and store current colors
+            current_colors = await self.get_downlight_colors()
+            self._stored_downlight_state = current_colors
+
+        # Create colors with brightness=0 for device
+        off_colors = [
+            HSBK(
+                hue=c.hue,
+                saturation=c.saturation,
+                brightness=0.0,
+                kelvin=c.kelvin,
+            )
+            for c in self._stored_downlight_state
+        ]
+
+        # Get all colors and update downlight zones
+        all_colors = await self.get_all_tile_colors()
+        tile_colors = all_colors[0]
+        tile_colors[self.downlight_zones] = off_colors
+        await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
+
+        # Update cache
+        self._last_downlight_colors = off_colors
+
+        # Persist if enabled
+        if self._state_file:
+            self._save_state_to_file()
+
+    async def _determine_uplight_brightness(self) -> HSBK:
+        """Determine uplight brightness using priority logic.
+
+        Priority order:
+        1. Stored state (if available)
+        2. Infer from downlight average brightness
+        3. Hardcoded default (0.8)
+
+        Returns:
+            HSBK color for uplight
+        """
+        # 1. Stored state
+        if self._stored_uplight_state is not None:
+            return self._stored_uplight_state
+
+        # Get current uplight color for H, S, K
+        current_uplight = await self.get_uplight_color()
+
+        # 2. Infer from downlight average brightness
+        try:
+            downlight_colors = await self.get_downlight_colors()
+            avg_brightness = sum(c.brightness for c in downlight_colors) / len(
+                downlight_colors
+            )
+
+            # Only use inferred brightness if it's > 0
+            # If all downlights are off (brightness=0), skip to default
+            if avg_brightness > 0:
+                return HSBK(
+                    hue=current_uplight.hue,
+                    saturation=current_uplight.saturation,
+                    brightness=avg_brightness,
+                    kelvin=current_uplight.kelvin,
+                )
+        except Exception:  # nosec B110
+            # If inference fails, fall through to default
+            pass
+
+        # 3. Hardcoded default (0.8)
+        return HSBK(
+            hue=current_uplight.hue,
+            saturation=current_uplight.saturation,
+            brightness=0.8,
+            kelvin=current_uplight.kelvin,
+        )
+
+    async def _determine_downlight_brightness(self) -> list[HSBK]:
+        """Determine downlight brightness using priority logic.
+
+        Priority order:
+        1. Stored state (if available)
+        2. Infer from uplight brightness
+        3. Hardcoded default (0.8)
+
+        Returns:
+            List of HSBK colors for downlight zones
+        """
+        # 1. Stored state
+        if self._stored_downlight_state is not None:
+            return self._stored_downlight_state
+
+        # Get current downlight colors for H, S, K
+        current_downlight = await self.get_downlight_colors()
+
+        # 2. Infer from uplight brightness
+        try:
+            uplight_color = await self.get_uplight_color()
+
+            # Only use inferred brightness if it's > 0
+            # If uplight is off (brightness=0), skip to default
+            if uplight_color.brightness > 0:
+                return [
+                    HSBK(
+                        hue=c.hue,
+                        saturation=c.saturation,
+                        brightness=uplight_color.brightness,
+                        kelvin=c.kelvin,
+                    )
+                    for c in current_downlight
+                ]
+        except Exception:  # nosec B110
+            # If inference fails, fall through to default
+            pass
+
+        # 3. Hardcoded default (0.8)
+        return [
+            HSBK(
+                hue=c.hue,
+                saturation=c.saturation,
+                brightness=0.8,
+                kelvin=c.kelvin,
+            )
+            for c in current_downlight
+        ]
+
+    def _is_stored_state_valid(
+        self, component: str, current: HSBK | list[HSBK]
+    ) -> bool:
+        """Check if stored state matches current (ignoring brightness).
+
+        Args:
+            component: Either "uplight" or "downlight"
+            current: Current color(s) from device
+
+        Returns:
+            True if stored state matches current (H, S, K), False otherwise
+        """
+        if component == "uplight":
+            if self._stored_uplight_state is None or not isinstance(current, HSBK):
+                return False
+
+            stored = self._stored_uplight_state
+            return (
+                stored.hue == current.hue
+                and stored.saturation == current.saturation
+                and stored.kelvin == current.kelvin
+            )
+
+        if component == "downlight":
+            if self._stored_downlight_state is None or not isinstance(current, list):
+                return False
+
+            if len(self._stored_downlight_state) != len(current):
+                return False
+
+            # Check if all zones match (H, S, K)
+            return all(
+                s.hue == c.hue and s.saturation == c.saturation and s.kelvin == c.kelvin
+                for s, c in zip(self._stored_downlight_state, current)
+            )
+
+        return False
+
+    def _load_state_from_file(self) -> None:
+        """Load state from JSON file.
+
+        Handles file not found and JSON errors gracefully.
+        """
+        if not self._state_file:
+            return
+
+        try:
+            state_path = Path(self._state_file).expanduser()
+            if not state_path.exists():
+                _LOGGER.debug("State file does not exist: %s", state_path)
+                return
+
+            with state_path.open("r") as f:
+                data = json.load(f)
+
+            # Get state for this device
+            device_state = data.get(self.serial)
+            if not device_state:
+                _LOGGER.debug("No state found for device %s", self.serial)
+                return
+
+            # Load uplight state
+            if "uplight" in device_state:
+                uplight_data = device_state["uplight"]
+                self._stored_uplight_state = HSBK(
+                    hue=uplight_data["hue"],
+                    saturation=uplight_data["saturation"],
+                    brightness=uplight_data["brightness"],
+                    kelvin=uplight_data["kelvin"],
+                )
+
+            # Load downlight state
+            if "downlight" in device_state:
+                downlight_data = device_state["downlight"]
+                self._stored_downlight_state = [
+                    HSBK(
+                        hue=c["hue"],
+                        saturation=c["saturation"],
+                        brightness=c["brightness"],
+                        kelvin=c["kelvin"],
+                    )
+                    for c in downlight_data
+                ]
+
+            _LOGGER.debug("Loaded state from %s for device %s", state_path, self.serial)
+
+        except Exception as e:
+            _LOGGER.warning("Failed to load state from %s: %s", self._state_file, e)
+
+    def _save_state_to_file(self) -> None:
+        """Save state to JSON file.
+
+        Handles file I/O errors gracefully.
+        """
+        if not self._state_file:
+            return
+
+        try:
+            state_path = Path(self._state_file).expanduser()
+
+            # Load existing data or create new
+            if state_path.exists():
+                with state_path.open("r") as f:
+                    data = json.load(f)
+            else:
+                data = {}
+
+            # Update state for this device
+            device_state = {}
+
+            if self._stored_uplight_state:
+                device_state["uplight"] = {
+                    "hue": self._stored_uplight_state.hue,
+                    "saturation": self._stored_uplight_state.saturation,
+                    "brightness": self._stored_uplight_state.brightness,
+                    "kelvin": self._stored_uplight_state.kelvin,
+                }
+
+            if self._stored_downlight_state:
+                device_state["downlight"] = [
+                    {
+                        "hue": c.hue,
+                        "saturation": c.saturation,
+                        "brightness": c.brightness,
+                        "kelvin": c.kelvin,
+                    }
+                    for c in self._stored_downlight_state
+                ]
+
+            data[self.serial] = device_state
+
+            # Ensure directory exists
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Write to file
+            with state_path.open("w") as f:
+                json.dump(data, f, indent=2)
+
+            _LOGGER.debug("Saved state to %s for device %s", state_path, self.serial)
+
+        except Exception as e:
+            _LOGGER.warning("Failed to save state to %s: %s", self._state_file, e)

--- a/src/lifx/network/discovery.py
+++ b/src/lifx/network/discovery.py
@@ -56,8 +56,8 @@ class DiscoveredDevice:
 
         Queries the device for its product ID and uses the product registry
         to instantiate the appropriate device class (Device, Light, HevLight,
-        InfraredLight, MultiZoneLight, or MatrixLight) based on the product
-        capabilities.
+        InfraredLight, MultiZoneLight, MatrixLight, or CeilingLight) based on
+        the product capabilities.
 
         This is the single source of truth for device type detection and
         instantiation across the library.
@@ -79,11 +79,13 @@ class DiscoveredDevice:
             ```
         """
         from lifx.devices.base import Device
+        from lifx.devices.ceiling import CeilingLight
         from lifx.devices.hev import HevLight
         from lifx.devices.infrared import InfraredLight
         from lifx.devices.light import Light
         from lifx.devices.matrix import MatrixLight
         from lifx.devices.multizone import MultiZoneLight
+        from lifx.products import is_ceiling_product
 
         kwargs = {
             "serial": self.serial,
@@ -100,6 +102,12 @@ class DiscoveredDevice:
             await temp_device._ensure_capabilities()
 
             if temp_device.capabilities:
+                # Check for Ceiling products first (before generic MatrixLight)
+                if temp_device.version and is_ceiling_product(
+                    temp_device.version.product
+                ):
+                    return CeilingLight(**kwargs)
+
                 if temp_device.capabilities.has_matrix:
                     return MatrixLight(**kwargs)
                 if temp_device.capabilities.has_multizone:

--- a/src/lifx/products/__init__.py
+++ b/src/lifx/products/__init__.py
@@ -9,6 +9,11 @@ products.json specification.
 To update: run `uv run python -m lifx.products.generator`
 """
 
+from lifx.products.quirks import (
+    CeilingComponentLayout,
+    get_ceiling_layout,
+    is_ceiling_product,
+)
 from lifx.products.registry import (
     ProductCapability,
     ProductInfo,
@@ -19,10 +24,13 @@ from lifx.products.registry import (
 )
 
 __all__ = [
+    "CeilingComponentLayout",
     "ProductCapability",
     "ProductInfo",
     "ProductRegistry",
     "TemperatureRange",
+    "get_ceiling_layout",
     "get_product",
     "get_registry",
+    "is_ceiling_product",
 ]

--- a/src/lifx/products/quirks.py
+++ b/src/lifx/products/quirks.py
@@ -1,0 +1,91 @@
+"""Product-specific quirks and metadata not available in products.json.
+
+This module provides additional metadata for LIFX products that is not included
+in the official products.json specification. These quirks are manually maintained
+and should be updated as needed when new products are released or when LIFX adds
+this information to products.json.
+
+Note:
+    If LIFX adds any of this information to products.json in the future,
+    the generator should be updated to include it in the auto-generated registry,
+    and the corresponding quirk should be removed from this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CeilingComponentLayout:
+    """Component layout for LIFX Ceiling lights.
+
+    Ceiling lights have two logical components:
+    - Uplight: Single zone for ambient/indirect lighting
+    - Downlight: Multiple zones for main illumination
+
+    Attributes:
+        width: Matrix width in zones
+        height: Matrix height in zones
+        uplight_zone: Zone index for the uplight component
+        downlight_zones: Slice representing downlight component zones
+    """
+
+    width: int
+    height: int
+    uplight_zone: int
+    downlight_zones: slice
+
+
+# Ceiling product component layouts
+# TODO: Remove once LIFX adds component layout metadata to products.json
+CEILING_LAYOUTS: dict[int, CeilingComponentLayout] = {
+    176: CeilingComponentLayout(  # Ceiling (US)
+        width=8,
+        height=8,
+        uplight_zone=63,
+        downlight_zones=slice(0, 63),
+    ),
+    177: CeilingComponentLayout(  # Ceiling (Intl)
+        width=8,
+        height=8,
+        uplight_zone=63,
+        downlight_zones=slice(0, 63),
+    ),
+    201: CeilingComponentLayout(  # Ceiling Capsule (US)
+        width=16,
+        height=8,
+        uplight_zone=127,
+        downlight_zones=slice(0, 127),
+    ),
+    202: CeilingComponentLayout(  # Ceiling Capsule (Intl)
+        width=16,
+        height=8,
+        uplight_zone=127,
+        downlight_zones=slice(0, 127),
+    ),
+}
+
+
+def get_ceiling_layout(pid: int) -> CeilingComponentLayout | None:
+    """Get component layout for a Ceiling product.
+
+    Args:
+        pid: Product ID
+
+    Returns:
+        CeilingComponentLayout if product is a Ceiling light, None otherwise
+    """
+    return CEILING_LAYOUTS.get(pid)
+
+
+def is_ceiling_product(pid: int) -> bool:
+    """Check if product ID is a Ceiling light.
+
+    Args:
+        pid: Product ID
+
+    Returns:
+        True if product is a Ceiling light
+    """
+    return pid in CEILING_LAYOUTS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from lifx_emulator.scenarios.models import ScenarioConfig
 from lifx.api import DeviceGroup
 from lifx.devices import HevLight, InfraredLight, Light, MultiZoneLight
 from lifx.devices.base import Device
+from lifx.devices.ceiling import CeilingLight
 from lifx.devices.matrix import MatrixLight
 from lifx.network.connection import DeviceConnection
 
@@ -299,13 +300,13 @@ async def cleanup_device_connections(request, emulator_available):
 def ceiling_device(
     emulator_server: tuple[int, EmulatedLifxServer, HierarchicalScenarioManager],
 ):
-    """Create a LIFX Ceiling device (product 201) for SKY effect testing.
+    """Create a LIFX Ceiling device (product 201) for SKY effect and component testing.
 
     The Ceiling device supports SKY effects and has >128 zones (16x8 tile).
     This fixture dynamically adds the device to the running emulator.
 
     Returns:
-        MatrixLight instance for the Ceiling device
+        CeilingLight instance for the Ceiling device
     """
     port, server, scenario_manager = emulator_server
 
@@ -313,6 +314,7 @@ def ceiling_device(
         pytest.skip("Cannot create ceiling device with external emulator")
 
     # Create Ceiling device (product 201 = LIFX Ceiling with 16x8 = 128 zones)
+    # Let the emulator use its internal product configuration
     ceiling = create_device(
         product_id=201,
         serial="d073d5000100",
@@ -320,7 +322,7 @@ def ceiling_device(
     )
     server.add_device(ceiling)
 
-    yield MatrixLight(
+    yield CeilingLight(
         serial="d073d5000100",
         ip="127.0.0.1",
         port=port,

--- a/tests/test_devices/test_ceiling.py
+++ b/tests/test_devices/test_ceiling.py
@@ -1,0 +1,905 @@
+"""Tests for CeilingLight device class."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lifx.color import HSBK
+from lifx.devices.ceiling import CeilingLight
+from lifx.products import get_ceiling_layout
+
+
+class TestCeilingLightComponentDetection:
+    """Tests for component detection and configuration."""
+
+    def test_create_ceiling_light_176(self) -> None:
+        """Test creating Ceiling light (product 176 - US)."""
+        ceiling = CeilingLight(
+            serial="d073d5010203",
+            ip="192.168.1.100",
+        )
+        assert ceiling.serial == "d073d5010203"
+        assert ceiling.ip == "192.168.1.100"
+
+        # Verify component layout for 8x8 ceiling (product 176)
+        layout = get_ceiling_layout(176)
+        assert layout is not None
+        assert layout.uplight_zone == 63
+        assert layout.downlight_zones == slice(0, 63)
+
+    def test_create_ceiling_light_177(self) -> None:
+        """Test creating Ceiling light (product 177 - Intl)."""
+        ceiling = CeilingLight(
+            serial="d073d5010204",
+            ip="192.168.1.101",
+        )
+        assert ceiling.serial == "d073d5010204"
+        assert ceiling.ip == "192.168.1.101"
+
+        # Verify component layout for 8x8 ceiling (product 177)
+        layout = get_ceiling_layout(177)
+        assert layout is not None
+        assert layout.uplight_zone == 63
+        assert layout.downlight_zones == slice(0, 63)
+
+    def test_create_ceiling_light_201(self) -> None:
+        """Test creating Ceiling Capsule (product 201 - US)."""
+        ceiling = CeilingLight(
+            serial="d073d5010205",
+            ip="192.168.1.102",
+        )
+        assert ceiling.serial == "d073d5010205"
+        assert ceiling.ip == "192.168.1.102"
+
+        # Verify component layout for 16x8 ceiling (product 201)
+        layout = get_ceiling_layout(201)
+        assert layout is not None
+        assert layout.uplight_zone == 127
+        assert layout.downlight_zones == slice(0, 127)
+
+    def test_create_ceiling_light_202(self) -> None:
+        """Test creating Ceiling Capsule (product 202 - Intl)."""
+        ceiling = CeilingLight(
+            serial="d073d5010206",
+            ip="192.168.1.103",
+        )
+        assert ceiling.serial == "d073d5010206"
+        assert ceiling.ip == "192.168.1.103"
+
+        # Verify component layout for 16x8 ceiling (product 202)
+        layout = get_ceiling_layout(202)
+        assert layout is not None
+        assert layout.uplight_zone == 127
+        assert layout.downlight_zones == slice(0, 127)
+
+    def test_uplight_zone_property(self) -> None:
+        """Test uplight_zone property returns correct zone index."""
+        ceiling_176 = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        # Mock version property
+        ceiling_176._version = MagicMock()
+        ceiling_176._version.product = 176
+
+        ceiling_201 = CeilingLight(serial="d073d5010205", ip="192.168.1.102")
+        ceiling_201._version = MagicMock()
+        ceiling_201._version.product = 201
+
+        assert ceiling_176.uplight_zone == 63
+        assert ceiling_201.uplight_zone == 127
+
+    def test_downlight_zones_property(self) -> None:
+        """Test downlight_zones property returns correct slice."""
+        ceiling_176 = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling_176._version = MagicMock()
+        ceiling_176._version.product = 176
+
+        ceiling_201 = CeilingLight(serial="d073d5010205", ip="192.168.1.102")
+        ceiling_201._version = MagicMock()
+        ceiling_201._version.product = 201
+
+        assert ceiling_176.downlight_zones == slice(0, 63)
+        assert ceiling_201.downlight_zones == slice(0, 127)
+
+
+class TestCeilingLightGetMethods:
+    """Tests for getting component colors."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 (8x8) instance with mocked connection."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling.connection = AsyncMock()
+        # Mock version for product detection
+        ceiling._version = MagicMock()
+        ceiling._version.product = 176
+        return ceiling
+
+    async def test_get_uplight_color(self, ceiling_176: CeilingLight) -> None:
+        """Test getting uplight component color."""
+        # Mock get_all_tile_colors to return list[list[HSBK]] (tiles -> colors per tile)
+        expected_uplight = HSBK(hue=30, saturation=0.2, brightness=0.3, kelvin=2700)
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        downlight_colors = [white] * 63
+        tile_colors = downlight_colors + [expected_uplight]  # 64 colors for 8x8 tile
+        all_colors = [tile_colors]  # Wrap in list to represent single tile
+
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=all_colors)
+
+        # Get uplight color
+        result = await ceiling_176.get_uplight_color()
+
+        assert result == expected_uplight
+        ceiling_176.get_all_tile_colors.assert_called_once()
+
+    async def test_get_downlight_colors(self, ceiling_176: CeilingLight) -> None:
+        """Test getting downlight component colors."""
+        # Mock get_all_tile_colors to return list[list[HSBK]] (tiles -> colors per tile)
+        expected_downlight = [
+            HSBK(hue=i * 5, saturation=1.0, brightness=1.0, kelvin=3500)
+            for i in range(63)
+        ]
+        uplight_color = HSBK(hue=200, saturation=0.5, brightness=0.5, kelvin=2700)
+        tile_colors = expected_downlight + [uplight_color]  # 64 colors for 8x8 tile
+        all_colors = [tile_colors]  # Wrap in list to represent single tile
+
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=all_colors)
+
+        # Get downlight colors
+        result = await ceiling_176.get_downlight_colors()
+
+        assert len(result) == 63
+        assert result == expected_downlight
+        ceiling_176.get_all_tile_colors.assert_called_once()
+
+
+class TestCeilingLightSetMethods:
+    """Tests for setting component colors."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 (8x8) instance with mocked connection."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling.connection = AsyncMock()
+        ceiling.set_matrix_colors = AsyncMock()
+        ceiling._save_state_to_file = MagicMock()
+
+        # Mock get_all_tile_colors to return current state (64 zones for 8x8 tile)
+        # Default to all white zones
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        default_tile_colors = [white] * 64
+        ceiling.get_all_tile_colors = AsyncMock(return_value=[default_tile_colors])
+
+        # Mock version for product detection
+        ceiling._version = MagicMock()
+        ceiling._version.product = 176
+        return ceiling
+
+    async def test_set_uplight_color(self, ceiling_176: CeilingLight) -> None:
+        """Test setting uplight component color."""
+        color = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
+
+        await ceiling_176.set_uplight_color(color, duration=1.0)
+
+        # Verify set_matrix_colors was called correctly
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert call_args.args[0] == 0  # tile_index
+        assert len(call_args.args[1]) == 64  # colors list (all zones)
+        assert call_args.args[1][63] == color  # uplight zone (last zone)
+        assert call_args.kwargs.get("duration") == 1000  # duration in milliseconds
+
+        # Verify stored state was updated
+        assert ceiling_176._stored_uplight_state == color
+
+    async def test_set_uplight_color_zero_brightness_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test setting uplight with brightness=0 raises ValueError."""
+        invalid_color = HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500)
+
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.set_uplight_color(invalid_color)
+
+    async def test_set_downlight_colors_single_hsbk(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test setting downlight to single color."""
+        color = HSBK(hue=0, saturation=0, brightness=1.0, kelvin=3500)
+
+        await ceiling_176.set_downlight_colors(color, duration=0.5)
+
+        # Verify set_matrix_colors was called correctly
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert call_args.args[0] == 0  # tile_index
+        assert len(call_args.args[1]) == 64  # colors list (all zones)
+        # Check downlight zones (0-62) are set to the color
+        assert all(call_args.args[1][i] == color for i in range(63))
+        assert call_args.kwargs.get("duration") == 500  # duration in milliseconds
+
+        # Verify stored state was updated
+        assert len(ceiling_176._stored_downlight_state) == 63
+        assert all(c == color for c in ceiling_176._stored_downlight_state)
+
+    async def test_set_downlight_colors_list_hsbk(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test setting downlight to list of colors."""
+        # Create colors with hue values 0-310 (step of 5) to stay under 360
+        colors = [
+            HSBK(hue=i * 5, saturation=1.0, brightness=1.0, kelvin=3500)
+            for i in range(63)
+        ]
+
+        await ceiling_176.set_downlight_colors(colors)
+
+        # Verify set_matrix_colors was called correctly
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert call_args.args[0] == 0  # tile_index
+        assert len(call_args.args[1]) == 64  # colors list (all zones)
+        # Check downlight zones (0-62) are set to the provided colors
+        assert call_args.args[1][0:63] == colors
+
+        # Verify stored state was updated
+        assert ceiling_176._stored_downlight_state == colors
+
+    async def test_set_downlight_colors_invalid_length_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test setting downlight with wrong number of colors raises ValueError."""
+        red = HSBK(hue=0, saturation=1.0, brightness=1.0, kelvin=3500)
+        invalid_colors = [red] * 10  # Wrong number
+
+        with pytest.raises(ValueError, match="Expected 63 colors"):
+            await ceiling_176.set_downlight_colors(invalid_colors)
+
+    async def test_set_downlight_colors_all_zero_brightness_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test setting downlight with all brightness=0 raises ValueError."""
+        invalid_colors = [HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500)] * 63
+
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.set_downlight_colors(invalid_colors)
+
+    async def test_set_downlight_colors_some_zero_brightness_allowed(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test setting downlight with some brightness=0 is allowed."""
+        # Some zones can be brightness=0, just not all
+        colors = [
+            HSBK(hue=0, saturation=0, brightness=0.0 if i < 10 else 1.0, kelvin=3500)
+            for i in range(63)
+        ]
+
+        await ceiling_176.set_downlight_colors(colors)
+
+        # Should succeed - verify it was called
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        assert call_args.args[0] == 0  # tile_index
+        assert len(call_args.args[1]) == 64  # colors list (all zones)
+
+
+class TestCeilingLightTurnOnOff:
+    """Tests for turning components on and off."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 (8x8) instance with mocked connection."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling.connection = AsyncMock()
+        ceiling.set_matrix_colors = AsyncMock()
+        ceiling._save_state_to_file = MagicMock()
+
+        # Mock get_all_tile_colors to return current state (64 zones for 8x8 tile)
+        # Default to all white zones
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        default_tile_colors = [white] * 64
+        ceiling.get_all_tile_colors = AsyncMock(return_value=[default_tile_colors])
+
+        # Mock version for product detection
+        ceiling._version = MagicMock()
+        ceiling._version.product = 176
+        return ceiling
+
+    async def test_turn_uplight_on_with_color(self, ceiling_176: CeilingLight) -> None:
+        """Test turning uplight on with explicit color."""
+        color = HSBK(hue=120, saturation=1.0, brightness=0.8, kelvin=3500)
+
+        await ceiling_176.turn_uplight_on(color)
+
+        # Verify set_matrix_colors was called
+        ceiling_176.set_matrix_colors.assert_called_once()
+        # Verify stored state was updated
+        assert ceiling_176._stored_uplight_state == color
+
+    async def test_turn_uplight_on_without_color_uses_stored(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning uplight on without color uses stored state."""
+        stored_color = HSBK(hue=60, saturation=0.5, brightness=0.7, kelvin=4000)
+        ceiling_176._stored_uplight_state = stored_color
+
+        await ceiling_176.turn_uplight_on()
+
+        # Should use stored state
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert call_args.args[0] == 0  # tile_index
+        assert call_args.args[1][63] == stored_color  # uplight zone
+
+    async def test_turn_uplight_on_infers_from_downlight(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning uplight on infers brightness from downlight average."""
+        # No stored state
+        ceiling_176._stored_uplight_state = None
+
+        # Mock downlight colors with average brightness 0.6
+        downlight_colors = [
+            HSBK(hue=0, saturation=0, brightness=0.6, kelvin=3500) for _ in range(63)
+        ]
+        uplight_color = HSBK(
+            hue=30, saturation=0.2, brightness=0.0, kelvin=2700
+        )  # Currently off
+        tile_colors = downlight_colors + [uplight_color]  # 64 colors for 8x8 tile
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=[tile_colors])
+
+        await ceiling_176.turn_uplight_on()
+
+        # Should infer brightness (0.6) from downlight
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_color = call_args.args[1][63]  # uplight zone
+        assert result_color.brightness == pytest.approx(0.6, abs=0.01)
+        assert result_color.hue == pytest.approx(30, abs=1)
+        assert result_color.kelvin == 2700
+
+    async def test_turn_uplight_on_uses_default_brightness(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn uplight on uses default brightness when no stored state."""
+        # No stored state
+        ceiling_176._stored_uplight_state = None
+
+        # Mock current uplight color (off) and downlight colors (all off too)
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.0, kelvin=2700)
+        downlight_colors = [
+            HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500) for _ in range(63)
+        ]
+        tile_colors = downlight_colors + [uplight_color]  # 64 colors for 8x8 tile
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=[tile_colors])
+
+        await ceiling_176.turn_uplight_on()
+
+        # Should use default brightness (0.8)
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_color = call_args.args[1][63]  # uplight zone
+        assert result_color.brightness == pytest.approx(0.8, abs=0.01)
+
+    async def test_turn_uplight_off_stores_current_color(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning uplight off stores current color."""
+        current_uplight = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        downlight_colors = [white] * 63
+        tile_colors = downlight_colors + [current_uplight]  # 64 colors for 8x8 tile
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=[tile_colors])
+
+        await ceiling_176.turn_uplight_off()
+
+        # Should store current color (with brightness preserved)
+        assert ceiling_176._stored_uplight_state is not None
+        assert ceiling_176._stored_uplight_state.brightness == pytest.approx(
+            0.5, abs=0.01
+        )
+
+        # Should set device to brightness=0
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_color = call_args.args[1][63]  # uplight zone
+        assert result_color.brightness == 0.0
+
+    async def test_turn_uplight_off_with_color_stores_provided(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning uplight off with explicit color stores that color."""
+        provided_color = HSBK(hue=120, saturation=0.8, brightness=0.6, kelvin=4000)
+
+        await ceiling_176.turn_uplight_off(provided_color)
+
+        # Should store provided color
+        assert ceiling_176._stored_uplight_state == provided_color
+
+        # Should set device to brightness=0 (with provided H, S, K)
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_color = call_args.args[1][63]  # uplight zone
+        assert result_color.brightness == 0.0
+        assert result_color.hue == pytest.approx(120, abs=1)
+        assert result_color.kelvin == 4000
+
+    async def test_turn_downlight_on_with_single_color(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning downlight on with single color."""
+        color = HSBK(hue=180, saturation=0.8, brightness=1.0, kelvin=5000)
+
+        await ceiling_176.turn_downlight_on(color)
+
+        # Should expand to all 63 zones (plus uplight zone = 64 total)
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert len(call_args.args[1]) == 64  # all zones
+        # Check downlight zones (0-62) are set to color
+        assert all(call_args.args[1][i] == color for i in range(63))
+
+    async def test_turn_downlight_on_with_list_colors(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning downlight on with list of colors."""
+        # Create colors with hue values 0-310 (step of 5) to stay under 360
+        colors = [
+            HSBK(hue=i * 5, saturation=1.0, brightness=1.0, kelvin=3500)
+            for i in range(63)
+        ]
+
+        await ceiling_176.turn_downlight_on(colors)
+
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert len(call_args.args[1]) == 64  # all zones
+        # Check downlight zones (0-62) match provided colors
+        assert call_args.args[1][0:63] == colors
+
+    async def test_turn_downlight_on_without_color_uses_stored(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning downlight on without color uses stored state."""
+        # Create colors with hue values 0-310 (step of 5) to stay under 360
+        stored_colors = [
+            HSBK(hue=i * 5, saturation=1.0, brightness=0.7, kelvin=3500)
+            for i in range(63)
+        ]
+        ceiling_176._stored_downlight_state = stored_colors
+
+        await ceiling_176.turn_downlight_on()
+
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        assert len(call_args.args[1]) == 64  # all zones
+        # Check downlight zones (0-62) match stored colors
+        assert call_args.args[1][0:63] == stored_colors
+
+    async def test_turn_downlight_on_infers_from_uplight(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning downlight on infers brightness from uplight."""
+        # No stored state
+        ceiling_176._stored_downlight_state = None
+
+        # Mock uplight with brightness 0.5
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
+        # Mock current downlight colors (off, but with different H, S, K)
+        # Create colors with hue values 0-310 (step of 5) to stay under 360
+        downlight_colors = [
+            HSBK(hue=i * 5, saturation=0.8, brightness=0.0, kelvin=3500)
+            for i in range(63)
+        ]
+        tile_colors = downlight_colors + [uplight_color]  # 64 colors for 8x8 tile
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=[tile_colors])
+
+        await ceiling_176.turn_downlight_on()
+
+        # Should use uplight brightness (0.5) for all downlight zones
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_colors = call_args.args[1]  # all zones
+        # Check downlight zones (0-62) have brightness from uplight
+        assert all(
+            result_colors[i].brightness == pytest.approx(0.5, abs=0.01)
+            for i in range(63)
+        )
+        # H, S, K should be preserved from current downlight
+        assert result_colors[0].hue == pytest.approx(0, abs=1)
+        assert result_colors[0].kelvin == 3500
+
+    async def test_turn_downlight_off_stores_current_colors(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning downlight off stores current colors."""
+        # Create colors with hue values 0-310 (step of 5) to stay under 360
+        current_downlight = [
+            HSBK(hue=i * 5, saturation=1.0, brightness=0.8, kelvin=3500)
+            for i in range(63)
+        ]
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.3, kelvin=2700)
+        tile_colors = current_downlight + [uplight_color]  # 64 colors for 8x8 tile
+        ceiling_176.get_all_tile_colors = AsyncMock(return_value=[tile_colors])
+
+        await ceiling_176.turn_downlight_off()
+
+        # Should store current colors (with brightness preserved)
+        assert ceiling_176._stored_downlight_state is not None
+        assert len(ceiling_176._stored_downlight_state) == 63
+        assert all(
+            c.brightness == pytest.approx(0.8, abs=0.01)
+            for c in ceiling_176._stored_downlight_state
+        )
+
+        # Should set device to brightness=0
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_colors = call_args.args[1]  # all zones
+        # Check downlight zones (0-62) have brightness=0
+        assert all(result_colors[i].brightness == 0.0 for i in range(63))
+
+    async def test_turn_downlight_off_with_color_stores_provided(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turning downlight off with explicit color stores that color."""
+        provided_color = HSBK(hue=240, saturation=0.9, brightness=0.6, kelvin=4500)
+
+        await ceiling_176.turn_downlight_off(provided_color)
+
+        # Should store provided color for all zones
+        assert ceiling_176._stored_downlight_state is not None
+        assert len(ceiling_176._stored_downlight_state) == 63
+        assert all(c == provided_color for c in ceiling_176._stored_downlight_state)
+
+        # Should set device to brightness=0
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        # Args: (tile_index, colors, duration=...)
+        result_colors = call_args.args[1]  # all zones
+        # Check downlight zones (0-62) have brightness=0
+        assert all(result_colors[i].brightness == 0.0 for i in range(63))
+
+    async def test_validation_turn_on_with_zero_brightness_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_on methods reject brightness=0."""
+        invalid_color = HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500)
+
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.turn_uplight_on(invalid_color)
+
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.turn_downlight_on(invalid_color)
+
+    async def test_validation_turn_off_with_zero_brightness_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_off methods reject brightness=0."""
+        invalid_color = HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500)
+
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.turn_uplight_off(invalid_color)
+
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.turn_downlight_off(invalid_color)
+
+
+class TestCeilingLightProperties:
+    """Tests for component state properties."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 (8x8) instance."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling.connection = AsyncMock()
+        # Mock cached power state
+        ceiling._state = MagicMock()
+        ceiling._state.power = 65535  # Power on
+        # Mock version for product detection
+        ceiling._version = MagicMock()
+        ceiling._version.product = 176
+        return ceiling
+
+    def test_uplight_is_on_when_on(self, ceiling_176: CeilingLight) -> None:
+        """Test uplight_is_on returns True when uplight is on."""
+        # Set cached uplight color with brightness > 0
+        ceiling_176._last_uplight_color = HSBK(
+            hue=30, saturation=0.2, brightness=0.5, kelvin=2700
+        )
+
+        assert ceiling_176.uplight_is_on is True
+
+    def test_uplight_is_on_when_off(self, ceiling_176: CeilingLight) -> None:
+        """Test uplight_is_on returns False when uplight is off."""
+        # Set cached uplight color with brightness = 0
+        ceiling_176._last_uplight_color = HSBK(
+            hue=30, saturation=0.2, brightness=0.0, kelvin=2700
+        )
+
+        assert ceiling_176.uplight_is_on is False
+
+    def test_uplight_is_on_when_power_off(self, ceiling_176: CeilingLight) -> None:
+        """Test uplight_is_on returns False when device power is off."""
+        ceiling_176._state.power = 0  # Power off
+        ceiling_176._last_uplight_color = HSBK(
+            hue=30, saturation=0.2, brightness=0.5, kelvin=2700
+        )
+
+        assert ceiling_176.uplight_is_on is False
+
+    def test_uplight_is_on_when_no_cached_data(self, ceiling_176: CeilingLight) -> None:
+        """Test uplight_is_on returns False when no cached data."""
+        ceiling_176._last_uplight_color = None
+
+        assert ceiling_176.uplight_is_on is False
+
+    def test_downlight_is_on_when_on(self, ceiling_176: CeilingLight) -> None:
+        """Test downlight_is_on returns True when any downlight zone is on."""
+        # Set some zones with brightness > 0
+        ceiling_176._last_downlight_colors = [
+            HSBK(hue=0, saturation=0, brightness=0.0 if i < 10 else 1.0, kelvin=3500)
+            for i in range(63)
+        ]
+
+        assert ceiling_176.downlight_is_on is True
+
+    def test_downlight_is_on_when_all_off(self, ceiling_176: CeilingLight) -> None:
+        """Test downlight_is_on returns False when all zones are off."""
+        # All zones with brightness = 0
+        ceiling_176._last_downlight_colors = [
+            HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500) for _ in range(63)
+        ]
+
+        assert ceiling_176.downlight_is_on is False
+
+    def test_downlight_is_on_when_power_off(self, ceiling_176: CeilingLight) -> None:
+        """Test downlight_is_on returns False when device power is off."""
+        ceiling_176._state.power = 0  # Power off
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        ceiling_176._last_downlight_colors = [white] * 63
+
+        assert ceiling_176.downlight_is_on is False
+
+    def test_downlight_is_on_when_no_cached_data(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test downlight_is_on returns False when no cached data."""
+        ceiling_176._last_downlight_colors = None
+
+        assert ceiling_176.downlight_is_on is False
+
+
+class TestCeilingLightStatePersistence:
+    """Tests for state persistence to JSON file."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 with temporary state file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / "ceiling_state.json"
+            ceiling = CeilingLight(
+                serial="d073d5010203",
+                ip="192.168.1.100",
+                state_file=str(state_file),
+            )
+            ceiling.connection = AsyncMock()
+            ceiling.set_matrix_colors = AsyncMock()
+            ceiling.get_all_tile_colors = AsyncMock()
+
+            # Mock version for product detection
+            ceiling._version = MagicMock()
+            ceiling._version.product = 176
+            yield ceiling
+
+    async def test_state_file_created_on_save(self, ceiling_176: CeilingLight) -> None:
+        """Test state file is created when saving state."""
+        # Set some state
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
+        ceiling_176._stored_uplight_state = uplight_color
+
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        downlight_colors = [white] * 63
+        ceiling_176._stored_downlight_state = downlight_colors
+
+        # Save to file
+        ceiling_176._save_state_to_file()
+
+        # Verify file exists
+        assert Path(ceiling_176._state_file).exists()
+
+        # Verify content
+        with open(ceiling_176._state_file) as f:
+            data = json.load(f)
+
+        assert "d073d5010203" in data
+        assert "uplight" in data["d073d5010203"]
+        assert "downlight" in data["d073d5010203"]
+
+    async def test_state_loaded_from_file(self, ceiling_176: CeilingLight) -> None:
+        """Test state is loaded from file on initialization."""
+        # Create state file manually
+        state_data = {
+            "d073d5010203": {
+                "uplight": {
+                    "hue": 30.0,
+                    "saturation": 0.2,
+                    "brightness": 0.5,
+                    "kelvin": 2700,
+                },
+                "downlight": [
+                    {"hue": 0.0, "saturation": 0.0, "brightness": 1.0, "kelvin": 3500}
+                ]
+                * 63,
+            }
+        }
+
+        with open(ceiling_176._state_file, "w") as f:
+            json.dump(state_data, f)
+
+        # Load state
+        ceiling_176._load_state_from_file()
+
+        # Verify loaded state
+        assert ceiling_176._stored_uplight_state is not None
+        assert ceiling_176._stored_uplight_state.hue == pytest.approx(30, abs=1)
+        assert ceiling_176._stored_uplight_state.brightness == pytest.approx(
+            0.5, abs=0.01
+        )
+
+        assert ceiling_176._stored_downlight_state is not None
+        assert len(ceiling_176._stored_downlight_state) == 63
+        assert all(
+            c.brightness == pytest.approx(1.0, abs=0.01)
+            for c in ceiling_176._stored_downlight_state
+        )
+
+    async def test_state_persistence_across_operations(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test state persists across set and turn_off operations."""
+        # Set uplight color
+        uplight_color = HSBK(hue=60, saturation=0.5, brightness=0.7, kelvin=4000)
+        await ceiling_176.set_uplight_color(uplight_color)
+
+        # Verify state was saved
+        assert Path(ceiling_176._state_file).exists()
+
+        # Create new instance with same state file
+        ceiling_new = CeilingLight(
+            serial="d073d5010203",
+            ip="192.168.1.100",
+            state_file=ceiling_176._state_file,
+        )
+        ceiling_new._load_state_from_file()
+
+        # Verify state was loaded
+        assert ceiling_new._stored_uplight_state is not None
+        assert ceiling_new._stored_uplight_state.hue == pytest.approx(60, abs=1)
+        assert ceiling_new._stored_uplight_state.brightness == pytest.approx(
+            0.7, abs=0.01
+        )
+
+
+class TestCeilingLightBackwardCompatibility:
+    """Tests for backward compatibility with MatrixLight."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 instance with mocked connection."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling.connection = AsyncMock()
+        return ceiling
+
+    async def test_set_color_affects_both_components(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test inherited set_color affects both uplight and downlight."""
+        color = HSBK(hue=180, saturation=0.8, brightness=1.0, kelvin=5000)
+
+        # Mock the parent set_color method
+        ceiling_176.set_matrix_colors = AsyncMock()
+
+        await ceiling_176.set_color(color)
+
+        # Verify set_color was called (from parent class)
+        # This would set all zones including both components
+        assert ceiling_176.connection.request.called
+
+    async def test_matrixlight_methods_still_work(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test that MatrixLight methods are still available."""
+        # Verify MatrixLight methods exist
+        assert hasattr(ceiling_176, "get_device_chain")
+        assert hasattr(ceiling_176, "get64")
+        assert hasattr(ceiling_176, "set64")
+        assert hasattr(ceiling_176, "set_matrix_colors")
+        assert hasattr(ceiling_176, "get_all_tile_colors")
+
+
+# Integration tests with emulator
+@pytest.mark.emulator
+class TestCeilingLightIntegration:
+    """Integration tests with lifx-emulator-core."""
+
+    async def test_ceiling_device_discovery(self, ceiling_device: CeilingLight) -> None:
+        """Test that ceiling device fixture is created correctly."""
+        async with ceiling_device:
+            # Verify it's a MatrixLight (CeilingLight inherits from MatrixLight)
+            assert isinstance(ceiling_device, CeilingLight)
+
+            # Verify component layout
+            assert ceiling_device.uplight_zone == 127  # Product 201
+            assert ceiling_device.downlight_zones == slice(0, 127)
+
+    async def test_ceiling_component_control(
+        self, ceiling_device: CeilingLight
+    ) -> None:
+        """Test controlling uplight and downlight independently."""
+        async with ceiling_device:
+            # Set uplight to warm white
+            uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.3, kelvin=2700)
+            await ceiling_device.set_uplight_color(uplight_color)
+
+            # Set downlight to cool white
+            downlight_color = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=5000)
+            await ceiling_device.set_downlight_colors(downlight_color)
+
+            # Read back and verify
+            uplight = await ceiling_device.get_uplight_color()
+            downlight = await ceiling_device.get_downlight_colors()
+
+            # Verify uplight (allow protocol conversion tolerance)
+            assert uplight.hue == pytest.approx(30, abs=5)
+            assert uplight.saturation == pytest.approx(0.2, abs=0.05)
+            assert uplight.brightness == pytest.approx(0.3, abs=0.05)
+            assert uplight.kelvin == pytest.approx(2700, abs=100)
+
+            # Verify downlight
+            assert len(downlight) == 127
+            assert all(c.brightness == pytest.approx(1.0, abs=0.05) for c in downlight)
+
+    async def test_ceiling_turn_components_on_off(
+        self, ceiling_device: CeilingLight
+    ) -> None:
+        """Test turning components on and off independently."""
+        async with ceiling_device:
+            # Turn both on with specific colors
+            uplight_color = HSBK(hue=120, saturation=0.8, brightness=0.5, kelvin=3500)
+            downlight_color = HSBK(hue=240, saturation=0.6, brightness=0.7, kelvin=4000)
+
+            await ceiling_device.turn_uplight_on(uplight_color)
+            await ceiling_device.turn_downlight_on(downlight_color)
+
+            # Turn uplight off (should preserve color in stored state)
+            await ceiling_device.turn_uplight_off()
+
+            # Verify uplight is off but downlight is still on
+            uplight = await ceiling_device.get_uplight_color()
+            downlight = await ceiling_device.get_downlight_colors()
+
+            assert uplight.brightness == pytest.approx(0.0, abs=0.01)
+            assert all(c.brightness == pytest.approx(0.7, abs=0.05) for c in downlight)
+
+            # Turn uplight back on (should restore from stored state)
+            await ceiling_device.turn_uplight_on()
+
+            uplight = await ceiling_device.get_uplight_color()
+            assert uplight.brightness == pytest.approx(0.5, abs=0.05)

--- a/uv.lock
+++ b/uv.lock
@@ -1,12 +1,6 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform != 'Windows'",
-    "python_full_version >= '3.13' and sys_platform == 'Windows'",
-    "python_full_version < '3.13' and sys_platform != 'Windows'",
-    "python_full_version < '3.13' and sys_platform == 'Windows'",
-]
 
 [[package]]
 name = "annotated-types"
@@ -28,38 +22,38 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "5.9"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/a7/312f673df6a79003279e1f55619abbe7daebbb87c17c976ddc0345c04c7b/backrefs-5.9.tar.gz", hash = "sha256:808548cb708d66b82ee231f962cb36faaf4f2baab032f2fbb783e9c2fdddaa59", size = 5765857, upload-time = "2025-06-22T19:34:13.97Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/4d/798dc1f30468134906575156c089c492cf79b5a5fd373f07fe26c4d046bf/backrefs-5.9-py310-none-any.whl", hash = "sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f", size = 380267, upload-time = "2025-06-22T19:34:05.252Z" },
-    { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
 ]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.2"
+version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2025.10.5"
+version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
 ]
 
 [[package]]
@@ -137,14 +131,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -158,89 +152,89 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.11.0"
+version = "7.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/38/ee22495420457259d2f3390309505ea98f98a5eed40901cf62196abad006/coverage-7.11.0.tar.gz", hash = "sha256:167bd504ac1ca2af7ff3b81d245dfea0292c5032ebef9d66cc08a7d28c1b8050", size = 811905, upload-time = "2025-10-15T15:15:08.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/26/4a96807b193b011588099c3b5c89fbb05294e5b90e71018e065465f34eb6/coverage-7.12.0.tar.gz", hash = "sha256:fc11e0a4e372cb5f282f16ef90d4a585034050ccda536451901abfb19a57f40c", size = 819341, upload-time = "2025-11-18T13:34:20.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/3a/ee1074c15c408ddddddb1db7dd904f6b81bc524e01f5a1c5920e13dbde23/coverage-7.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d58ecaa865c5b9fa56e35efc51d1014d4c0d22838815b9fce57a27dd9576847", size = 215912, upload-time = "2025-10-15T15:12:40.665Z" },
-    { url = "https://files.pythonhosted.org/packages/70/c4/9f44bebe5cb15f31608597b037d78799cc5f450044465bcd1ae8cb222fe1/coverage-7.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b679e171f1c104a5668550ada700e3c4937110dbdd153b7ef9055c4f1a1ee3cc", size = 216310, upload-time = "2025-10-15T15:12:42.461Z" },
-    { url = "https://files.pythonhosted.org/packages/42/01/5e06077cfef92d8af926bdd86b84fb28bf9bc6ad27343d68be9b501d89f2/coverage-7.11.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ca61691ba8c5b6797deb221a0d09d7470364733ea9c69425a640f1f01b7c5bf0", size = 246706, upload-time = "2025-10-15T15:12:44.001Z" },
-    { url = "https://files.pythonhosted.org/packages/40/b8/7a3f1f33b35cc4a6c37e759137533119560d06c0cc14753d1a803be0cd4a/coverage-7.11.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aef1747ede4bd8ca9cfc04cc3011516500c6891f1b33a94add3253f6f876b7b7", size = 248634, upload-time = "2025-10-15T15:12:45.768Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/41/7f987eb33de386bc4c665ab0bf98d15fcf203369d6aacae74f5dd8ec489a/coverage-7.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1839d08406e4cba2953dcc0ffb312252f14d7c4c96919f70167611f4dee2623", size = 250741, upload-time = "2025-10-15T15:12:47.222Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c1/a4e0ca6a4e83069fb8216b49b30a7352061ca0cb38654bd2dc96b7b3b7da/coverage-7.11.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e0eb0a2dcc62478eb5b4cbb80b97bdee852d7e280b90e81f11b407d0b81c4287", size = 246837, upload-time = "2025-10-15T15:12:48.904Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/03/ced062a17f7c38b4728ff76c3acb40d8465634b20b4833cdb3cc3a74e115/coverage-7.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bc1fbea96343b53f65d5351d8fd3b34fd415a2670d7c300b06d3e14a5af4f552", size = 248429, upload-time = "2025-10-15T15:12:50.73Z" },
-    { url = "https://files.pythonhosted.org/packages/97/af/a7c6f194bb8c5a2705ae019036b8fe7f49ea818d638eedb15fdb7bed227c/coverage-7.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:214b622259dd0cf435f10241f1333d32caa64dbc27f8790ab693428a141723de", size = 246490, upload-time = "2025-10-15T15:12:52.646Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c3/aab4df02b04a8fde79068c3c41ad7a622b0ef2b12e1ed154da986a727c3f/coverage-7.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:258d9967520cca899695d4eb7ea38be03f06951d6ca2f21fb48b1235f791e601", size = 246208, upload-time = "2025-10-15T15:12:54.586Z" },
-    { url = "https://files.pythonhosted.org/packages/30/d8/e282ec19cd658238d60ed404f99ef2e45eed52e81b866ab1518c0d4163cf/coverage-7.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cf9e6ff4ca908ca15c157c409d608da77a56a09877b97c889b98fb2c32b6465e", size = 247126, upload-time = "2025-10-15T15:12:56.485Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/17/a635fa07fac23adb1a5451ec756216768c2767efaed2e4331710342a3399/coverage-7.11.0-cp311-cp311-win32.whl", hash = "sha256:fcc15fc462707b0680cff6242c48625da7f9a16a28a41bb8fd7a4280920e676c", size = 218314, upload-time = "2025-10-15T15:12:58.365Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/29/2ac1dfcdd4ab9a70026edc8d715ece9b4be9a1653075c658ee6f271f394d/coverage-7.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:865965bf955d92790f1facd64fe7ff73551bd2c1e7e6b26443934e9701ba30b9", size = 219203, upload-time = "2025-10-15T15:12:59.902Z" },
-    { url = "https://files.pythonhosted.org/packages/03/21/5ce8b3a0133179115af4c041abf2ee652395837cb896614beb8ce8ddcfd9/coverage-7.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:5693e57a065760dcbeb292d60cc4d0231a6d4b6b6f6a3191561e1d5e8820b745", size = 217879, upload-time = "2025-10-15T15:13:01.35Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/db/86f6906a7c7edc1a52b2c6682d6dd9be775d73c0dfe2b84f8923dfea5784/coverage-7.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9c49e77811cf9d024b95faf86c3f059b11c0c9be0b0d61bc598f453703bd6fd1", size = 216098, upload-time = "2025-10-15T15:13:02.916Z" },
-    { url = "https://files.pythonhosted.org/packages/21/54/e7b26157048c7ba555596aad8569ff903d6cd67867d41b75287323678ede/coverage-7.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a61e37a403a778e2cda2a6a39abcc895f1d984071942a41074b5c7ee31642007", size = 216331, upload-time = "2025-10-15T15:13:04.403Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/19/1ce6bf444f858b83a733171306134a0544eaddf1ca8851ede6540a55b2ad/coverage-7.11.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c79cae102bb3b1801e2ef1511fb50e91ec83a1ce466b2c7c25010d884336de46", size = 247825, upload-time = "2025-10-15T15:13:05.92Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/d3bcbbc259fcced5fb67c5d78f6e7ee965f49760c14afd931e9e663a83b2/coverage-7.11.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:16ce17ceb5d211f320b62df002fa7016b7442ea0fd260c11cec8ce7730954893", size = 250573, upload-time = "2025-10-15T15:13:07.471Z" },
-    { url = "https://files.pythonhosted.org/packages/58/8d/b0ff3641a320abb047258d36ed1c21d16be33beed4152628331a1baf3365/coverage-7.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80027673e9d0bd6aef86134b0771845e2da85755cf686e7c7c59566cf5a89115", size = 251706, upload-time = "2025-10-15T15:13:09.4Z" },
-    { url = "https://files.pythonhosted.org/packages/59/c8/5a586fe8c7b0458053d9c687f5cff515a74b66c85931f7fe17a1c958b4ac/coverage-7.11.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d3ffa07a08657306cd2215b0da53761c4d73cb54d9143b9303a6481ec0cd415", size = 248221, upload-time = "2025-10-15T15:13:10.964Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ff/3a25e3132804ba44cfa9a778cdf2b73dbbe63ef4b0945e39602fc896ba52/coverage-7.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a3b6a5f8b2524fd6c1066bc85bfd97e78709bb5e37b5b94911a6506b65f47186", size = 249624, upload-time = "2025-10-15T15:13:12.5Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/12/ff10c8ce3895e1b17a73485ea79ebc1896a9e466a9d0f4aef63e0d17b718/coverage-7.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:fcc0a4aa589de34bc56e1a80a740ee0f8c47611bdfb28cd1849de60660f3799d", size = 247744, upload-time = "2025-10-15T15:13:14.554Z" },
-    { url = "https://files.pythonhosted.org/packages/16/02/d500b91f5471b2975947e0629b8980e5e90786fe316b6d7299852c1d793d/coverage-7.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dba82204769d78c3fd31b35c3d5f46e06511936c5019c39f98320e05b08f794d", size = 247325, upload-time = "2025-10-15T15:13:16.438Z" },
-    { url = "https://files.pythonhosted.org/packages/77/11/dee0284fbbd9cd64cfce806b827452c6df3f100d9e66188e82dfe771d4af/coverage-7.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81b335f03ba67309a95210caf3eb43bd6fe75a4e22ba653ef97b4696c56c7ec2", size = 249180, upload-time = "2025-10-15T15:13:17.959Z" },
-    { url = "https://files.pythonhosted.org/packages/59/1b/cdf1def928f0a150a057cab03286774e73e29c2395f0d30ce3d9e9f8e697/coverage-7.11.0-cp312-cp312-win32.whl", hash = "sha256:037b2d064c2f8cc8716fe4d39cb705779af3fbf1ba318dc96a1af858888c7bb5", size = 218479, upload-time = "2025-10-15T15:13:19.608Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/55/e5884d55e031da9c15b94b90a23beccc9d6beee65e9835cd6da0a79e4f3a/coverage-7.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:d66c0104aec3b75e5fd897e7940188ea1892ca1d0235316bf89286d6a22568c0", size = 219290, upload-time = "2025-10-15T15:13:21.593Z" },
-    { url = "https://files.pythonhosted.org/packages/23/a8/faa930cfc71c1d16bc78f9a19bb73700464f9c331d9e547bfbc1dbd3a108/coverage-7.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:d91ebeac603812a09cf6a886ba6e464f3bbb367411904ae3790dfe28311b15ad", size = 217924, upload-time = "2025-10-15T15:13:23.39Z" },
-    { url = "https://files.pythonhosted.org/packages/60/7f/85e4dfe65e400645464b25c036a26ac226cf3a69d4a50c3934c532491cdd/coverage-7.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cc3f49e65ea6e0d5d9bd60368684fe52a704d46f9e7fc413918f18d046ec40e1", size = 216129, upload-time = "2025-10-15T15:13:25.371Z" },
-    { url = "https://files.pythonhosted.org/packages/96/5d/dc5fa98fea3c175caf9d360649cb1aa3715e391ab00dc78c4c66fabd7356/coverage-7.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f39ae2f63f37472c17b4990f794035c9890418b1b8cca75c01193f3c8d3e01be", size = 216380, upload-time = "2025-10-15T15:13:26.976Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f5/3da9cc9596708273385189289c0e4d8197d37a386bdf17619013554b3447/coverage-7.11.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7db53b5cdd2917b6eaadd0b1251cf4e7d96f4a8d24e174bdbdf2f65b5ea7994d", size = 247375, upload-time = "2025-10-15T15:13:28.923Z" },
-    { url = "https://files.pythonhosted.org/packages/65/6c/f7f59c342359a235559d2bc76b0c73cfc4bac7d61bb0df210965cb1ecffd/coverage-7.11.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:10ad04ac3a122048688387828b4537bc9cf60c0bf4869c1e9989c46e45690b82", size = 249978, upload-time = "2025-10-15T15:13:30.525Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/8c/042dede2e23525e863bf1ccd2b92689692a148d8b5fd37c37899ba882645/coverage-7.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4036cc9c7983a2b1f2556d574d2eb2154ac6ed55114761685657e38782b23f52", size = 251253, upload-time = "2025-10-15T15:13:32.174Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a9/3c58df67bfa809a7bddd786356d9c5283e45d693edb5f3f55d0986dd905a/coverage-7.11.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7ab934dd13b1c5e94b692b1e01bd87e4488cb746e3a50f798cb9464fd128374b", size = 247591, upload-time = "2025-10-15T15:13:34.147Z" },
-    { url = "https://files.pythonhosted.org/packages/26/5b/c7f32efd862ee0477a18c41e4761305de6ddd2d49cdeda0c1116227570fd/coverage-7.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59a6e5a265f7cfc05f76e3bb53eca2e0dfe90f05e07e849930fecd6abb8f40b4", size = 249411, upload-time = "2025-10-15T15:13:38.425Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b5/78cb4f1e86c1611431c990423ec0768122905b03837e1b4c6a6f388a858b/coverage-7.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:df01d6c4c81e15a7c88337b795bb7595a8596e92310266b5072c7e301168efbd", size = 247303, upload-time = "2025-10-15T15:13:40.464Z" },
-    { url = "https://files.pythonhosted.org/packages/87/c9/23c753a8641a330f45f221286e707c427e46d0ffd1719b080cedc984ec40/coverage-7.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8c934bd088eed6174210942761e38ee81d28c46de0132ebb1801dbe36a390dcc", size = 247157, upload-time = "2025-10-15T15:13:42.087Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/42/6e0cc71dc8a464486e944a4fa0d85bdec031cc2969e98ed41532a98336b9/coverage-7.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5a03eaf7ec24078ad64a07f02e30060aaf22b91dedf31a6b24d0d98d2bba7f48", size = 248921, upload-time = "2025-10-15T15:13:43.715Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/1c/743c2ef665e6858cccb0f84377dfe3a4c25add51e8c7ef19249be92465b6/coverage-7.11.0-cp313-cp313-win32.whl", hash = "sha256:695340f698a5f56f795b2836abe6fb576e7c53d48cd155ad2f80fd24bc63a040", size = 218526, upload-time = "2025-10-15T15:13:45.336Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/d5/226daadfd1bf8ddbccefbd3aa3547d7b960fb48e1bdac124e2dd13a2b71a/coverage-7.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:2727d47fce3ee2bac648528e41455d1b0c46395a087a229deac75e9f88ba5a05", size = 219317, upload-time = "2025-10-15T15:13:47.401Z" },
-    { url = "https://files.pythonhosted.org/packages/97/54/47db81dcbe571a48a298f206183ba8a7ba79200a37cd0d9f4788fcd2af4a/coverage-7.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:0efa742f431529699712b92ecdf22de8ff198df41e43aeaaadf69973eb93f17a", size = 217948, upload-time = "2025-10-15T15:13:49.096Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8b/cb68425420154e7e2a82fd779a8cc01549b6fa83c2ad3679cd6c088ebd07/coverage-7.11.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:587c38849b853b157706407e9ebdca8fd12f45869edb56defbef2daa5fb0812b", size = 216837, upload-time = "2025-10-15T15:13:51.09Z" },
-    { url = "https://files.pythonhosted.org/packages/33/55/9d61b5765a025685e14659c8d07037247de6383c0385757544ffe4606475/coverage-7.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b971bdefdd75096163dd4261c74be813c4508477e39ff7b92191dea19f24cd37", size = 217061, upload-time = "2025-10-15T15:13:52.747Z" },
-    { url = "https://files.pythonhosted.org/packages/52/85/292459c9186d70dcec6538f06ea251bc968046922497377bf4a1dc9a71de/coverage-7.11.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:269bfe913b7d5be12ab13a95f3a76da23cf147be7fa043933320ba5625f0a8de", size = 258398, upload-time = "2025-10-15T15:13:54.45Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e2/46edd73fb8bf51446c41148d81944c54ed224854812b6ca549be25113ee0/coverage-7.11.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:dadbcce51a10c07b7c72b0ce4a25e4b6dcb0c0372846afb8e5b6307a121eb99f", size = 260574, upload-time = "2025-10-15T15:13:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/07/5e/1df469a19007ff82e2ca8fe509822820a31e251f80ee7344c34f6cd2ec43/coverage-7.11.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ed43fa22c6436f7957df036331f8fe4efa7af132054e1844918866cd228af6c", size = 262797, upload-time = "2025-10-15T15:13:58.635Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/50/de216b31a1434b94d9b34a964c09943c6be45069ec704bfc379d8d89a649/coverage-7.11.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9516add7256b6713ec08359b7b05aeff8850c98d357784c7205b2e60aa2513fa", size = 257361, upload-time = "2025-10-15T15:14:00.409Z" },
-    { url = "https://files.pythonhosted.org/packages/82/1e/3f9f8344a48111e152e0fd495b6fff13cc743e771a6050abf1627a7ba918/coverage-7.11.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb92e47c92fcbcdc692f428da67db33337fa213756f7adb6a011f7b5a7a20740", size = 260349, upload-time = "2025-10-15T15:14:02.188Z" },
-    { url = "https://files.pythonhosted.org/packages/65/9b/3f52741f9e7d82124272f3070bbe316006a7de1bad1093f88d59bfc6c548/coverage-7.11.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d06f4fc7acf3cabd6d74941d53329e06bab00a8fe10e4df2714f0b134bfc64ef", size = 258114, upload-time = "2025-10-15T15:14:03.907Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/8b/918f0e15f0365d50d3986bbd3338ca01178717ac5678301f3f547b6619e6/coverage-7.11.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:6fbcee1a8f056af07ecd344482f711f563a9eb1c2cad192e87df00338ec3cdb0", size = 256723, upload-time = "2025-10-15T15:14:06.324Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9e/7776829f82d3cf630878a7965a7d70cc6ca94f22c7d20ec4944f7148cb46/coverage-7.11.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dbbf012be5f32533a490709ad597ad8a8ff80c582a95adc8d62af664e532f9ca", size = 259238, upload-time = "2025-10-15T15:14:08.002Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/b8/49cf253e1e7a3bedb85199b201862dd7ca4859f75b6cf25ffa7298aa0760/coverage-7.11.0-cp313-cp313t-win32.whl", hash = "sha256:cee6291bb4fed184f1c2b663606a115c743df98a537c969c3c64b49989da96c2", size = 219180, upload-time = "2025-10-15T15:14:09.786Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/e1/1a541703826be7ae2125a0fb7f821af5729d56bb71e946e7b933cc7a89a4/coverage-7.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a386c1061bf98e7ea4758e4313c0ab5ecf57af341ef0f43a0bf26c2477b5c268", size = 220241, upload-time = "2025-10-15T15:14:11.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/d1/5ee0e0a08621140fd418ec4020f595b4d52d7eb429ae6a0c6542b4ba6f14/coverage-7.11.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f9ea02ef40bb83823b2b04964459d281688fe173e20643870bb5d2edf68bc836", size = 218510, upload-time = "2025-10-15T15:14:13.46Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/06/e923830c1985ce808e40a3fa3eb46c13350b3224b7da59757d37b6ce12b8/coverage-7.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c770885b28fb399aaf2a65bbd1c12bf6f307ffd112d6a76c5231a94276f0c497", size = 216110, upload-time = "2025-10-15T15:14:15.157Z" },
-    { url = "https://files.pythonhosted.org/packages/42/82/cdeed03bfead45203fb651ed756dfb5266028f5f939e7f06efac4041dad5/coverage-7.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3d0e2087dba64c86a6b254f43e12d264b636a39e88c5cc0a01a7c71bcfdab7e", size = 216395, upload-time = "2025-10-15T15:14:16.863Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ba/e1c80caffc3199aa699813f73ff097bc2df7b31642bdbc7493600a8f1de5/coverage-7.11.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:73feb83bb41c32811973b8565f3705caf01d928d972b72042b44e97c71fd70d1", size = 247433, upload-time = "2025-10-15T15:14:18.589Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c0/5b259b029694ce0a5bbc1548834c7ba3db41d3efd3474489d7efce4ceb18/coverage-7.11.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c6f31f281012235ad08f9a560976cc2fc9c95c17604ff3ab20120fe480169bca", size = 249970, upload-time = "2025-10-15T15:14:20.307Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/86/171b2b5e1aac7e2fd9b43f7158b987dbeb95f06d1fbecad54ad8163ae3e8/coverage-7.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9570ad567f880ef675673992222746a124b9595506826b210fbe0ce3f0499cd", size = 251324, upload-time = "2025-10-15T15:14:22.419Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7e/7e10414d343385b92024af3932a27a1caf75c6e27ee88ba211221ff1a145/coverage-7.11.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8badf70446042553a773547a61fecaa734b55dc738cacf20c56ab04b77425e43", size = 247445, upload-time = "2025-10-15T15:14:24.205Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/3b/e4f966b21f5be8c4bf86ad75ae94efa0de4c99c7bbb8114476323102e345/coverage-7.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a09c1211959903a479e389685b7feb8a17f59ec5a4ef9afde7650bd5eabc2777", size = 249324, upload-time = "2025-10-15T15:14:26.234Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a2/8479325576dfcd909244d0df215f077f47437ab852ab778cfa2f8bf4d954/coverage-7.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:5ef83b107f50db3f9ae40f69e34b3bd9337456c5a7fe3461c7abf8b75dd666a2", size = 247261, upload-time = "2025-10-15T15:14:28.42Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d8/3a9e2db19d94d65771d0f2e21a9ea587d11b831332a73622f901157cc24b/coverage-7.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f91f927a3215b8907e214af77200250bb6aae36eca3f760f89780d13e495388d", size = 247092, upload-time = "2025-10-15T15:14:30.784Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/b1/bbca3c472544f9e2ad2d5116b2379732957048be4b93a9c543fcd0207e5f/coverage-7.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cdbcd376716d6b7fbfeedd687a6c4be019c5a5671b35f804ba76a4c0a778cba4", size = 248755, upload-time = "2025-10-15T15:14:32.585Z" },
-    { url = "https://files.pythonhosted.org/packages/89/49/638d5a45a6a0f00af53d6b637c87007eb2297042186334e9923a61aa8854/coverage-7.11.0-cp314-cp314-win32.whl", hash = "sha256:bab7ec4bb501743edc63609320aaec8cd9188b396354f482f4de4d40a9d10721", size = 218793, upload-time = "2025-10-15T15:14:34.972Z" },
-    { url = "https://files.pythonhosted.org/packages/30/cc/b675a51f2d068adb3cdf3799212c662239b0ca27f4691d1fff81b92ea850/coverage-7.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:3d4ba9a449e9364a936a27322b20d32d8b166553bfe63059bd21527e681e2fad", size = 219587, upload-time = "2025-10-15T15:14:37.047Z" },
-    { url = "https://files.pythonhosted.org/packages/93/98/5ac886876026de04f00820e5094fe22166b98dcb8b426bf6827aaf67048c/coverage-7.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:ce37f215223af94ef0f75ac68ea096f9f8e8c8ec7d6e8c346ee45c0d363f0479", size = 218168, upload-time = "2025-10-15T15:14:38.861Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d1/b4145d35b3e3ecf4d917e97fc8895bcf027d854879ba401d9ff0f533f997/coverage-7.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f413ce6e07e0d0dc9c433228727b619871532674b45165abafe201f200cc215f", size = 216850, upload-time = "2025-10-15T15:14:40.651Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/d1/7f645fc2eccd318369a8a9948acc447bb7c1ade2911e31d3c5620544c22b/coverage-7.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:05791e528a18f7072bf5998ba772fe29db4da1234c45c2087866b5ba4dea710e", size = 217071, upload-time = "2025-10-15T15:14:42.755Z" },
-    { url = "https://files.pythonhosted.org/packages/54/7d/64d124649db2737ceced1dfcbdcb79898d5868d311730f622f8ecae84250/coverage-7.11.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cacb29f420cfeb9283b803263c3b9a068924474ff19ca126ba9103e1278dfa44", size = 258570, upload-time = "2025-10-15T15:14:44.542Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/3f/6f5922f80dc6f2d8b2c6f974835c43f53eb4257a7797727e6ca5b7b2ec1f/coverage-7.11.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314c24e700d7027ae3ab0d95fbf8d53544fca1f20345fd30cd219b737c6e58d3", size = 260738, upload-time = "2025-10-15T15:14:46.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/5f/9e883523c4647c860b3812b417a2017e361eca5b635ee658387dc11b13c1/coverage-7.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:630d0bd7a293ad2fc8b4b94e5758c8b2536fdf36c05f1681270203e463cbfa9b", size = 262994, upload-time = "2025-10-15T15:14:48.3Z" },
-    { url = "https://files.pythonhosted.org/packages/07/bb/43b5a8e94c09c8bf51743ffc65c4c841a4ca5d3ed191d0a6919c379a1b83/coverage-7.11.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e89641f5175d65e2dbb44db15fe4ea48fade5d5bbb9868fdc2b4fce22f4a469d", size = 257282, upload-time = "2025-10-15T15:14:50.236Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e5/0ead8af411411330b928733e1d201384b39251a5f043c1612970310e8283/coverage-7.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c9f08ea03114a637dab06cedb2e914da9dc67fa52c6015c018ff43fdde25b9c2", size = 260430, upload-time = "2025-10-15T15:14:52.413Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/66/03dd8bb0ba5b971620dcaac145461950f6d8204953e535d2b20c6b65d729/coverage-7.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce9f3bde4e9b031eaf1eb61df95c1401427029ea1bfddb8621c1161dcb0fa02e", size = 258190, upload-time = "2025-10-15T15:14:54.268Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ae/28a9cce40bf3174426cb2f7e71ee172d98e7f6446dff936a7ccecee34b14/coverage-7.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:e4dc07e95495923d6fd4d6c27bf70769425b71c89053083843fd78f378558996", size = 256658, upload-time = "2025-10-15T15:14:56.436Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/7c/3a44234a8599513684bfc8684878fd7b126c2760f79712bb78c56f19efc4/coverage-7.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:424538266794db2861db4922b05d729ade0940ee69dcf0591ce8f69784db0e11", size = 259342, upload-time = "2025-10-15T15:14:58.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/e6/0108519cba871af0351725ebdb8660fd7a0fe2ba3850d56d32490c7d9b4b/coverage-7.11.0-cp314-cp314t-win32.whl", hash = "sha256:4c1eeb3fb8eb9e0190bebafd0462936f75717687117339f708f395fe455acc73", size = 219568, upload-time = "2025-10-15T15:15:00.382Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/76/44ba876e0942b4e62fdde23ccb029ddb16d19ba1bef081edd00857ba0b16/coverage-7.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b56efee146c98dbf2cf5cffc61b9829d1e94442df4d7398b26892a53992d3547", size = 220687, upload-time = "2025-10-15T15:15:02.322Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/0c/0df55ecb20d0d0ed5c322e10a441775e1a3a5d78c60f0c4e1abfe6fcf949/coverage-7.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b5c2705afa83f49bd91962a4094b6b082f94aef7626365ab3f8f4bd159c5acf3", size = 218711, upload-time = "2025-10-15T15:15:04.575Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/04/642c1d8a448ae5ea1369eac8495740a79eb4e581a9fb0cbdce56bbf56da1/coverage-7.11.0-py3-none-any.whl", hash = "sha256:4b7589765348d78fb4e5fb6ea35d07564e387da2fc5efff62e0222971f155f68", size = 207761, upload-time = "2025-10-15T15:15:06.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/0c/0dfe7f0487477d96432e4815537263363fb6dd7289743a796e8e51eabdf2/coverage-7.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa124a3683d2af98bd9d9c2bfa7a5076ca7e5ab09fdb96b81fa7d89376ae928f", size = 217535, upload-time = "2025-11-18T13:32:08.812Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f5/f9a4a053a5bbff023d3bec259faac8f11a1e5a6479c2ccf586f910d8dac7/coverage-7.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d93fbf446c31c0140208dcd07c5d882029832e8ed7891a39d6d44bd65f2316c3", size = 218044, upload-time = "2025-11-18T13:32:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c5/84fc3697c1fa10cd8571919bf9693f693b7373278daaf3b73e328d502bc8/coverage-7.12.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:52ca620260bd8cd6027317bdd8b8ba929be1d741764ee765b42c4d79a408601e", size = 248440, upload-time = "2025-11-18T13:32:12.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/36/2d93fbf6a04670f3874aed397d5a5371948a076e3249244a9e84fb0e02d6/coverage-7.12.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f3433ffd541380f3a0e423cff0f4926d55b0cc8c1d160fdc3be24a4c03aa65f7", size = 250361, upload-time = "2025-11-18T13:32:13.852Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/49/66dc65cc456a6bfc41ea3d0758c4afeaa4068a2b2931bf83be6894cf1058/coverage-7.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7bbb321d4adc9f65e402c677cd1c8e4c2d0105d3ce285b51b4d87f1d5db5245", size = 252472, upload-time = "2025-11-18T13:32:15.068Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1f/ebb8a18dffd406db9fcd4b3ae42254aedcaf612470e8712f12041325930f/coverage-7.12.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22a7aade354a72dff3b59c577bfd18d6945c61f97393bc5fb7bd293a4237024b", size = 248592, upload-time = "2025-11-18T13:32:16.328Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/67f213c06e5ea3b3d4980df7dc344d7fea88240b5fe878a5dcbdfe0e2315/coverage-7.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ff651dcd36d2fea66877cd4a82de478004c59b849945446acb5baf9379a1b64", size = 250167, upload-time = "2025-11-18T13:32:17.687Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/e52aef68154164ea40cc8389c120c314c747fe63a04b013a5782e989b77f/coverage-7.12.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:31b8b2e38391a56e3cea39d22a23faaa7c3fc911751756ef6d2621d2a9daf742", size = 248238, upload-time = "2025-11-18T13:32:19.2Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a4/4d88750bcf9d6d66f77865e5a05a20e14db44074c25fd22519777cb69025/coverage-7.12.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:297bc2da28440f5ae51c845a47c8175a4db0553a53827886e4fb25c66633000c", size = 247964, upload-time = "2025-11-18T13:32:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/b74693158899d5b47b0bf6238d2c6722e20ba749f86b74454fac0696bb00/coverage-7.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ff7651cc01a246908eac162a6a86fc0dbab6de1ad165dfb9a1e2ec660b44984", size = 248862, upload-time = "2025-11-18T13:32:22.304Z" },
+    { url = "https://files.pythonhosted.org/packages/18/de/6af6730227ce0e8ade307b1cc4a08e7f51b419a78d02083a86c04ccceb29/coverage-7.12.0-cp311-cp311-win32.whl", hash = "sha256:313672140638b6ddb2c6455ddeda41c6a0b208298034544cfca138978c6baed6", size = 220033, upload-time = "2025-11-18T13:32:23.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/e7f63021a7c4fe20994359fcdeae43cbef4a4d0ca36a5a1639feeea5d9e1/coverage-7.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1783ed5bd0d5938d4435014626568dc7f93e3cb99bc59188cc18857c47aa3c4", size = 220966, upload-time = "2025-11-18T13:32:25.599Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e8/deae26453f37c20c3aa0c4433a1e32cdc169bf415cce223a693117aa3ddd/coverage-7.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:4648158fd8dd9381b5847622df1c90ff314efbfc1df4550092ab6013c238a5fc", size = 219637, upload-time = "2025-11-18T13:32:27.265Z" },
+    { url = "https://files.pythonhosted.org/packages/02/bf/638c0427c0f0d47638242e2438127f3c8ee3cfc06c7fdeb16778ed47f836/coverage-7.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:29644c928772c78512b48e14156b81255000dcfd4817574ff69def189bcb3647", size = 217704, upload-time = "2025-11-18T13:32:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e1/706fae6692a66c2d6b871a608bbde0da6281903fa0e9f53a39ed441da36a/coverage-7.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8638cbb002eaa5d7c8d04da667813ce1067080b9a91099801a0053086e52b736", size = 218064, upload-time = "2025-11-18T13:32:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8b/eb0231d0540f8af3ffda39720ff43cb91926489d01524e68f60e961366e4/coverage-7.12.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:083631eeff5eb9992c923e14b810a179798bb598e6a0dd60586819fc23be6e60", size = 249560, upload-time = "2025-11-18T13:32:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/67fb52af642e974d159b5b379e4d4c59d0ebe1288677fbd04bbffe665a82/coverage-7.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:99d5415c73ca12d558e07776bd957c4222c687b9f1d26fa0e1b57e3598bdcde8", size = 252318, upload-time = "2025-11-18T13:32:33.178Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e5/38228f31b2c7665ebf9bdfdddd7a184d56450755c7e43ac721c11a4b8dab/coverage-7.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e949ebf60c717c3df63adb4a1a366c096c8d7fd8472608cd09359e1bd48ef59f", size = 253403, upload-time = "2025-11-18T13:32:34.45Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4b/df78e4c8188f9960684267c5a4897836f3f0f20a20c51606ee778a1d9749/coverage-7.12.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d907ddccbca819afa2cd014bc69983b146cca2735a0b1e6259b2a6c10be1e70", size = 249984, upload-time = "2025-11-18T13:32:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/bb163933d195a345c6f63eab9e55743413d064c291b6220df754075c2769/coverage-7.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b1518ecbad4e6173f4c6e6c4a46e49555ea5679bf3feda5edb1b935c7c44e8a0", size = 251339, upload-time = "2025-11-18T13:32:37.352Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/c9b29cdb8412c837cdcbc2cfa054547dd83affe6cbbd4ce4fdb92b6ba7d1/coverage-7.12.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51777647a749abdf6f6fd8c7cffab12de68ab93aab15efc72fbbb83036c2a068", size = 249489, upload-time = "2025-11-18T13:32:39.212Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/da/b3131e20ba07a0de4437a50ef3b47840dfabf9293675b0cd5c2c7f66dd61/coverage-7.12.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:42435d46d6461a3b305cdfcad7cdd3248787771f53fe18305548cba474e6523b", size = 249070, upload-time = "2025-11-18T13:32:40.598Z" },
+    { url = "https://files.pythonhosted.org/packages/70/81/b653329b5f6302c08d683ceff6785bc60a34be9ae92a5c7b63ee7ee7acec/coverage-7.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5bcead88c8423e1855e64b8057d0544e33e4080b95b240c2a355334bb7ced937", size = 250929, upload-time = "2025-11-18T13:32:42.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/250ac3bca9f252a5fb1338b5ad01331ebb7b40223f72bef5b1b2cb03aa64/coverage-7.12.0-cp312-cp312-win32.whl", hash = "sha256:dcbb630ab034e86d2a0f79aefd2be07e583202f41e037602d438c80044957baa", size = 220241, upload-time = "2025-11-18T13:32:44.665Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1c/77e79e76d37ce83302f6c21980b45e09f8aa4551965213a10e62d71ce0ab/coverage-7.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:2fd8354ed5d69775ac42986a691fbf68b4084278710cee9d7c3eaa0c28fa982a", size = 221051, upload-time = "2025-11-18T13:32:46.008Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f5/641b8a25baae564f9e52cac0e2667b123de961985709a004e287ee7663cc/coverage-7.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:737c3814903be30695b2de20d22bcc5428fdae305c61ba44cdc8b3252984c49c", size = 219692, upload-time = "2025-11-18T13:32:47.372Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/14/771700b4048774e48d2c54ed0c674273702713c9ee7acdfede40c2666747/coverage-7.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47324fffca8d8eae7e185b5bb20c14645f23350f870c1649003618ea91a78941", size = 217725, upload-time = "2025-11-18T13:32:49.22Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a7/3aa4144d3bcb719bf67b22d2d51c2d577bf801498c13cb08f64173e80497/coverage-7.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ccf3b2ede91decd2fb53ec73c1f949c3e034129d1e0b07798ff1d02ea0c8fa4a", size = 218098, upload-time = "2025-11-18T13:32:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9c/b846bbc774ff81091a12a10203e70562c91ae71badda00c5ae5b613527b1/coverage-7.12.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b365adc70a6936c6b0582dc38746b33b2454148c02349345412c6e743efb646d", size = 249093, upload-time = "2025-11-18T13:32:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b6/67d7c0e1f400b32c883e9342de4a8c2ae7c1a0b57c5de87622b7262e2309/coverage-7.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bc13baf85cd8a4cfcf4a35c7bc9d795837ad809775f782f697bf630b7e200211", size = 251686, upload-time = "2025-11-18T13:32:54.862Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/75/b095bd4b39d49c3be4bffbb3135fea18a99a431c52dd7513637c0762fecb/coverage-7.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:099d11698385d572ceafb3288a5b80fe1fc58bf665b3f9d362389de488361d3d", size = 252930, upload-time = "2025-11-18T13:32:56.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f3/466f63015c7c80550bead3093aacabf5380c1220a2a93c35d374cae8f762/coverage-7.12.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:473dc45d69694069adb7680c405fb1e81f60b2aff42c81e2f2c3feaf544d878c", size = 249296, upload-time = "2025-11-18T13:32:58.074Z" },
+    { url = "https://files.pythonhosted.org/packages/27/86/eba2209bf2b7e28c68698fc13437519a295b2d228ba9e0ec91673e09fa92/coverage-7.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:583f9adbefd278e9de33c33d6846aa8f5d164fa49b47144180a0e037f0688bb9", size = 251068, upload-time = "2025-11-18T13:32:59.646Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/ca8ae7dbba962a3351f18940b359b94c6bafdd7757945fdc79ec9e452dc7/coverage-7.12.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b2089cc445f2dc0af6f801f0d1355c025b76c24481935303cf1af28f636688f0", size = 249034, upload-time = "2025-11-18T13:33:01.481Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d7/39136149325cad92d420b023b5fd900dabdd1c3a0d1d5f148ef4a8cedef5/coverage-7.12.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:950411f1eb5d579999c5f66c62a40961f126fc71e5e14419f004471957b51508", size = 248853, upload-time = "2025-11-18T13:33:02.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/b6/76e1add8b87ef60e00643b0b7f8f7bb73d4bf5249a3be19ebefc5793dd25/coverage-7.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b1aab7302a87bafebfe76b12af681b56ff446dc6f32ed178ff9c092ca776e6bc", size = 250619, upload-time = "2025-11-18T13:33:04.336Z" },
+    { url = "https://files.pythonhosted.org/packages/95/87/924c6dc64f9203f7a3c1832a6a0eee5a8335dbe5f1bdadcc278d6f1b4d74/coverage-7.12.0-cp313-cp313-win32.whl", hash = "sha256:d7e0d0303c13b54db495eb636bc2465b2fb8475d4c8bcec8fe4b5ca454dfbae8", size = 220261, upload-time = "2025-11-18T13:33:06.493Z" },
+    { url = "https://files.pythonhosted.org/packages/91/77/dd4aff9af16ff776bf355a24d87eeb48fc6acde54c907cc1ea89b14a8804/coverage-7.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:ce61969812d6a98a981d147d9ac583a36ac7db7766f2e64a9d4d059c2fe29d07", size = 221072, upload-time = "2025-11-18T13:33:07.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/49/5c9dc46205fef31b1b226a6e16513193715290584317fd4df91cdaf28b22/coverage-7.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bcec6f47e4cb8a4c2dc91ce507f6eefc6a1b10f58df32cdc61dff65455031dfc", size = 219702, upload-time = "2025-11-18T13:33:09.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/62/f87922641c7198667994dd472a91e1d9b829c95d6c29529ceb52132436ad/coverage-7.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:459443346509476170d553035e4a3eed7b860f4fe5242f02de1010501956ce87", size = 218420, upload-time = "2025-11-18T13:33:11.153Z" },
+    { url = "https://files.pythonhosted.org/packages/85/dd/1cc13b2395ef15dbb27d7370a2509b4aee77890a464fb35d72d428f84871/coverage-7.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:04a79245ab2b7a61688958f7a855275997134bc84f4a03bc240cf64ff132abf6", size = 218773, upload-time = "2025-11-18T13:33:12.569Z" },
+    { url = "https://files.pythonhosted.org/packages/74/40/35773cc4bb1e9d4658d4fb669eb4195b3151bef3bbd6f866aba5cd5dac82/coverage-7.12.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09a86acaaa8455f13d6a99221d9654df249b33937b4e212b4e5a822065f12aa7", size = 260078, upload-time = "2025-11-18T13:33:14.037Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ee/231bb1a6ffc2905e396557585ebc6bdc559e7c66708376d245a1f1d330fc/coverage-7.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:907e0df1b71ba77463687a74149c6122c3f6aac56c2510a5d906b2f368208560", size = 262144, upload-time = "2025-11-18T13:33:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/28/be/32f4aa9f3bf0b56f3971001b56508352c7753915345d45fab4296a986f01/coverage-7.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b57e2d0ddd5f0582bae5437c04ee71c46cd908e7bc5d4d0391f9a41e812dd12", size = 264574, upload-time = "2025-11-18T13:33:17.354Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7c/00489fcbc2245d13ab12189b977e0cf06ff3351cb98bc6beba8bd68c5902/coverage-7.12.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:58c1c6aa677f3a1411fe6fb28ec3a942e4f665df036a3608816e0847fad23296", size = 259298, upload-time = "2025-11-18T13:33:18.958Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b4/f0760d65d56c3bea95b449e02570d4abd2549dc784bf39a2d4721a2d8ceb/coverage-7.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4c589361263ab2953e3c4cd2a94db94c4ad4a8e572776ecfbad2389c626e4507", size = 262150, upload-time = "2025-11-18T13:33:20.644Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/9a9314df00f9326d78c1e5a910f520d599205907432d90d1c1b7a97aa4b1/coverage-7.12.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:91b810a163ccad2e43b1faa11d70d3cf4b6f3d83f9fd5f2df82a32d47b648e0d", size = 259763, upload-time = "2025-11-18T13:33:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/10/34/01a0aceed13fbdf925876b9a15d50862eb8845454301fe3cdd1df08b2182/coverage-7.12.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:40c867af715f22592e0d0fb533a33a71ec9e0f73a6945f722a0c85c8c1cbe3a2", size = 258653, upload-time = "2025-11-18T13:33:24.239Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/04/81d8fd64928acf1574bbb0181f66901c6c1c6279c8ccf5f84259d2c68ae9/coverage-7.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:68b0d0a2d84f333de875666259dadf28cc67858bc8fd8b3f1eae84d3c2bec455", size = 260856, upload-time = "2025-11-18T13:33:26.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/fa2a37bfaeaf1f766a2d2360a25a5297d4fb567098112f6517475eee120b/coverage-7.12.0-cp313-cp313t-win32.whl", hash = "sha256:73f9e7fbd51a221818fd11b7090eaa835a353ddd59c236c57b2199486b116c6d", size = 220936, upload-time = "2025-11-18T13:33:28.165Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/52/60f64d932d555102611c366afb0eb434b34266b1d9266fc2fe18ab641c47/coverage-7.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:24cff9d1f5743f67db7ba46ff284018a6e9aeb649b67aa1e70c396aa1b7cb23c", size = 222001, upload-time = "2025-11-18T13:33:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/77/df/c303164154a5a3aea7472bf323b7c857fed93b26618ed9fc5c2955566bb0/coverage-7.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c87395744f5c77c866d0f5a43d97cc39e17c7f1cb0115e54a2fe67ca75c5d14d", size = 220273, upload-time = "2025-11-18T13:33:31.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/fc12db0883478d6e12bbd62d481210f0c8daf036102aa11434a0c5755825/coverage-7.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a1c59b7dc169809a88b21a936eccf71c3895a78f5592051b1af8f4d59c2b4f92", size = 217777, upload-time = "2025-11-18T13:33:32.86Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c1/ce3e525d223350c6ec16b9be8a057623f54226ef7f4c2fee361ebb6a02b8/coverage-7.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8787b0f982e020adb732b9f051f3e49dd5054cebbc3f3432061278512a2b1360", size = 218100, upload-time = "2025-11-18T13:33:34.532Z" },
+    { url = "https://files.pythonhosted.org/packages/15/87/113757441504aee3808cb422990ed7c8bcc2d53a6779c66c5adef0942939/coverage-7.12.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ea5a9f7dc8877455b13dd1effd3202e0bca72f6f3ab09f9036b1bcf728f69ac", size = 249151, upload-time = "2025-11-18T13:33:36.135Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1d/9529d9bd44049b6b05bb319c03a3a7e4b0a8a802d28fa348ad407e10706d/coverage-7.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fdba9f15849534594f60b47c9a30bc70409b54947319a7c4fd0e8e3d8d2f355d", size = 251667, upload-time = "2025-11-18T13:33:37.996Z" },
+    { url = "https://files.pythonhosted.org/packages/11/bb/567e751c41e9c03dc29d3ce74b8c89a1e3396313e34f255a2a2e8b9ebb56/coverage-7.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a00594770eb715854fb1c57e0dea08cce6720cfbc531accdb9850d7c7770396c", size = 253003, upload-time = "2025-11-18T13:33:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b3/c2cce2d8526a02fb9e9ca14a263ca6fc074449b33a6afa4892838c903528/coverage-7.12.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5560c7e0d82b42eb1951e4f68f071f8017c824ebfd5a6ebe42c60ac16c6c2434", size = 249185, upload-time = "2025-11-18T13:33:42.086Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a7/967f93bb66e82c9113c66a8d0b65ecf72fc865adfba5a145f50c7af7e58d/coverage-7.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d6c2e26b481c9159c2773a37947a9718cfdc58893029cdfb177531793e375cfc", size = 251025, upload-time = "2025-11-18T13:33:43.634Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b2/f2f6f56337bc1af465d5b2dc1ee7ee2141b8b9272f3bf6213fcbc309a836/coverage-7.12.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6e1a8c066dabcde56d5d9fed6a66bc19a2883a3fe051f0c397a41fc42aedd4cc", size = 248979, upload-time = "2025-11-18T13:33:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7a/bf4209f45a4aec09d10a01a57313a46c0e0e8f4c55ff2965467d41a92036/coverage-7.12.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f7ba9da4726e446d8dd8aae5a6cd872511184a5d861de80a86ef970b5dacce3e", size = 248800, upload-time = "2025-11-18T13:33:47.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b7/1e01b8696fb0521810f60c5bbebf699100d6754183e6cc0679bf2ed76531/coverage-7.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e0f483ab4f749039894abaf80c2f9e7ed77bbf3c737517fb88c8e8e305896a17", size = 250460, upload-time = "2025-11-18T13:33:49.537Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ae/84324fb9cb46c024760e706353d9b771a81b398d117d8c1fe010391c186f/coverage-7.12.0-cp314-cp314-win32.whl", hash = "sha256:76336c19a9ef4a94b2f8dc79f8ac2da3f193f625bb5d6f51a328cd19bfc19933", size = 220533, upload-time = "2025-11-18T13:33:51.16Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/71/1033629deb8460a8f97f83e6ac4ca3b93952e2b6f826056684df8275e015/coverage-7.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7c1059b600aec6ef090721f8f633f60ed70afaffe8ecab85b59df748f24b31fe", size = 221348, upload-time = "2025-11-18T13:33:52.776Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5f/ac8107a902f623b0c251abdb749be282dc2ab61854a8a4fcf49e276fce2f/coverage-7.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:172cf3a34bfef42611963e2b661302a8931f44df31629e5b1050567d6b90287d", size = 219922, upload-time = "2025-11-18T13:33:54.316Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6e/f27af2d4da367f16077d21ef6fe796c874408219fa6dd3f3efe7751bd910/coverage-7.12.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:aa7d48520a32cb21c7a9b31f81799e8eaec7239db36c3b670be0fa2403828d1d", size = 218511, upload-time = "2025-11-18T13:33:56.343Z" },
+    { url = "https://files.pythonhosted.org/packages/67/dd/65fd874aa460c30da78f9d259400d8e6a4ef457d61ab052fd248f0050558/coverage-7.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:90d58ac63bc85e0fb919f14d09d6caa63f35a5512a2205284b7816cafd21bb03", size = 218771, upload-time = "2025-11-18T13:33:57.966Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e0/7c6b71d327d8068cb79c05f8f45bf1b6145f7a0de23bbebe63578fe5240a/coverage-7.12.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ca8ecfa283764fdda3eae1bdb6afe58bf78c2c3ec2b2edcb05a671f0bba7b3f9", size = 260151, upload-time = "2025-11-18T13:33:59.597Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ce/4697457d58285b7200de6b46d606ea71066c6e674571a946a6ea908fb588/coverage-7.12.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:874fe69a0785d96bd066059cd4368022cebbec1a8958f224f0016979183916e6", size = 262257, upload-time = "2025-11-18T13:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/33/acbc6e447aee4ceba88c15528dbe04a35fb4d67b59d393d2e0d6f1e242c1/coverage-7.12.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b3c889c0b8b283a24d721a9eabc8ccafcfc3aebf167e4cd0d0e23bf8ec4e339", size = 264671, upload-time = "2025-11-18T13:34:02.795Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/e2822a795c1ed44d569980097be839c5e734d4c0c1119ef8e0a073496a30/coverage-7.12.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bb5b894b3ec09dcd6d3743229dc7f2c42ef7787dc40596ae04c0edda487371e", size = 259231, upload-time = "2025-11-18T13:34:04.397Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c5/a7ec5395bb4a49c9b7ad97e63f0c92f6bf4a9e006b1393555a02dae75f16/coverage-7.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:79a44421cd5fba96aa57b5e3b5a4d3274c449d4c622e8f76882d76635501fd13", size = 262137, upload-time = "2025-11-18T13:34:06.068Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0c/02c08858b764129f4ecb8e316684272972e60777ae986f3865b10940bdd6/coverage-7.12.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:33baadc0efd5c7294f436a632566ccc1f72c867f82833eb59820ee37dc811c6f", size = 259745, upload-time = "2025-11-18T13:34:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/04/4fd32b7084505f3829a8fe45c1a74a7a728cb251aaadbe3bec04abcef06d/coverage-7.12.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c406a71f544800ef7e9e0000af706b88465f3573ae8b8de37e5f96c59f689ad1", size = 258570, upload-time = "2025-11-18T13:34:09.676Z" },
+    { url = "https://files.pythonhosted.org/packages/48/35/2365e37c90df4f5342c4fa202223744119fe31264ee2924f09f074ea9b6d/coverage-7.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e71bba6a40883b00c6d571599b4627f50c360b3d0d02bfc658168936be74027b", size = 260899, upload-time = "2025-11-18T13:34:11.259Z" },
+    { url = "https://files.pythonhosted.org/packages/05/56/26ab0464ca733fa325e8e71455c58c1c374ce30f7c04cebb88eabb037b18/coverage-7.12.0-cp314-cp314t-win32.whl", hash = "sha256:9157a5e233c40ce6613dead4c131a006adfda70e557b6856b97aceed01b0e27a", size = 221313, upload-time = "2025-11-18T13:34:12.863Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1c/017a3e1113ed34d998b27d2c6dba08a9e7cb97d362f0ec988fcd873dcf81/coverage-7.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e84da3a0fd233aeec797b981c51af1cabac74f9bd67be42458365b30d11b5291", size = 222423, upload-time = "2025-11-18T13:34:15.14Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/bcc504fdd5169301b52568802bb1b9cdde2e27a01d39fbb3b4b508ab7c2c/coverage-7.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:01d24af36fedda51c2b1aca56e4330a3710f83b02a5ff3743a6b015ffa7c9384", size = 220459, upload-time = "2025-11-18T13:34:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a3/43b749004e3c09452e39bb56347a008f0a0668aad37324a99b5c8ca91d9e/coverage-7.12.0-py3-none-any.whl", hash = "sha256:159d50c0b12e060b15ed3d39f87ed43d4f7f7ad40b8a534f4dd331adbb51104a", size = 209503, upload-time = "2025-11-18T13:34:18.892Z" },
 ]
 
 [package.optional-dependencies]
@@ -286,19 +280,19 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.14.0"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/6c09dd7ce4c7837e4cdb11dce980cb45ae3cd87677298dc3b781b6bce7d3/griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13", size = 424684, upload-time = "2025-09-05T15:02:29.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/b1/9ff6578d789a89812ff21e4e0f80ffae20a65d5dd84e7a17873fe3b365be/griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0", size = 144439, upload-time = "2025-09-05T15:02:27.511Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]
 name = "hatchling"
-version = "1.27.0"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
@@ -306,9 +300,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "trove-classifiers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/8e/e480359492affde4119a131da729dd26da742c2c9b604dff74836e47eef9/hatchling-1.28.0.tar.gz", hash = "sha256:4d50b02aece6892b8cd0b3ce6c82cb218594d3ec5836dbde75bf41a21ab004c8", size = 55365, upload-time = "2025-11-27T00:31:13.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a5/48cb7efb8b4718b1a4c0c331e3364a3a33f614ff0d6afd2b93ee883d3c47/hatchling-1.28.0-py3-none-any.whl", hash = "sha256:dc48722b68b3f4bbfa3ff618ca07cdea6750e7d03481289ffa8be1521d18a961", size = 76075, upload-time = "2025-11-27T00:31:12.544Z" },
 ]
 
 [[package]]
@@ -397,11 +391,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.9"
+version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/37/02347f6d6d8279247a5837082ebc26fc0d5aaeaf75aa013fcbb433c777ab/markdown-3.9.tar.gz", hash = "sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a", size = 364585, upload-time = "2025-09-04T20:25:22.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl", hash = "sha256:9f4d91ed810864ea88a6f32c07ba8bee1346c0cc1f6b1f9f6c822f2a9667d280", size = 107441, upload-time = "2025-09-04T20:25:21.784Z" },
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
 ]
 
 [[package]]
@@ -418,15 +412,15 @@ wheels = [
 
 [[package]]
 name = "markdownify"
-version = "1.2.0"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/1b/6f2697b51eaca81f08852fd2734745af15718fea10222a1d40f8a239c4ea/markdownify-1.2.0.tar.gz", hash = "sha256:f6c367c54eb24ee953921804dfe6d6575c5e5b42c643955e7242034435de634c", size = 18771, upload-time = "2025-08-09T17:44:15.302Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/e2/7af643acb4cae0741dffffaa7f3f7c9e7ab4046724543ba1777c401d821c/markdownify-1.2.0-py3-none-any.whl", hash = "sha256:48e150a1c4993d4d50f282f725c0111bd9eb25645d41fa2f543708fd44161351", size = 15561, upload-time = "2025-08-09T17:44:14.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
 ]
 
 [[package]]
@@ -600,22 +594,22 @@ wheels = [
 
 [[package]]
 name = "mkdocs-git-revision-date-localized-plugin"
-version = "1.4.7"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
     { name = "gitpython" },
     { name = "mkdocs" },
-    { name = "pytz" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f8/a17ec39a4fc314d40cc96afdc1d401e393ebd4f42309d454cc940a2cf38a/mkdocs_git_revision_date_localized_plugin-1.4.7.tar.gz", hash = "sha256:10a49eff1e1c3cb766e054b9d8360c904ce4fe8c33ac3f6cc083ac6459c91953", size = 450473, upload-time = "2025-05-28T18:26:20.697Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/c5/1d3c4e6ddae6230b89d09105cb79de711655e3ebd6745f7a92efea0f5160/mkdocs_git_revision_date_localized_plugin-1.5.0.tar.gz", hash = "sha256:17345ccfdf69a1905dc96fb1070dce82d03a1eb6b0d48f958081a7589ce3c248", size = 460697, upload-time = "2025-10-31T16:11:34.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b6/106fcc15287e7228658fbd0ad9e8b0d775becced0a089cc39984641f4a0f/mkdocs_git_revision_date_localized_plugin-1.4.7-py3-none-any.whl", hash = "sha256:056c0a90242409148f1dc94d5c9d2c25b5b8ddd8de45489fa38f7fa7ccad2bc4", size = 25382, upload-time = "2025-05-28T18:26:18.907Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/51/fe0e3fdb16f6eed65c9459d12bae6a4e1f0bb4e2228cb037e7907b002678/mkdocs_git_revision_date_localized_plugin-1.5.0-py3-none-any.whl", hash = "sha256:933f9e35a8c135b113f21bb57610d82e9b7bcc71dd34fb06a029053c97e99656", size = 26153, upload-time = "2025-10-31T16:11:32.987Z" },
 ]
 
 [[package]]
 name = "mkdocs-llmstxt"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -623,14 +617,14 @@ dependencies = [
     { name = "mdformat" },
     { name = "mdformat-tables" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/ed/5790e2b18349e17a61549114690ec6e48f5f673ccf8f4ca396412767ea2a/mkdocs_llmstxt-0.4.0.tar.gz", hash = "sha256:a7e4d20496bc8c55b6773b55c8d69cf552448a9ad38915b6e8c657ae3a46c8b8", size = 32048, upload-time = "2025-10-03T14:08:05.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/70/8b87783592a81685c0422c076525acbb50d0ec71c16554a17ffa375c9d69/mkdocs_llmstxt-0.4.0-py3-none-any.whl", hash = "sha256:7244bf0ac917c9964030c93e9c3e26c02d2d14a0f66fc113416007125b6da0fc", size = 11463, upload-time = "2025-10-03T14:08:03.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
 ]
 
 [[package]]
 name = "mkdocs-material"
-version = "9.6.22"
+version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -645,9 +639,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/5d/317e37b6c43325cb376a1d6439df9cc743b8ee41c84603c2faf7286afc82/mkdocs_material-9.6.22.tar.gz", hash = "sha256:87c158b0642e1ada6da0cbd798a3389b0bc5516b90e5ece4a0fb939f00bacd1c", size = 4044968, upload-time = "2025-10-15T09:21:15.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/3b/111b84cd6ff28d9e955b5f799ef217a17bc1684ac346af333e6100e413cb/mkdocs_material-9.7.0.tar.gz", hash = "sha256:602b359844e906ee402b7ed9640340cf8a474420d02d8891451733b6b02314ec", size = 4094546, upload-time = "2025-11-11T08:49:09.73Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/82/6fdb9a7a04fb222f4849ffec1006f891a0280825a20314d11f3ccdee14eb/mkdocs_material-9.6.22-py3-none-any.whl", hash = "sha256:14ac5f72d38898b2f98ac75a5531aaca9366eaa427b0f49fc2ecf04d99b7ad84", size = 9206252, upload-time = "2025-10-15T09:21:12.175Z" },
+    { url = "https://files.pythonhosted.org/packages/04/87/eefe8d5e764f4cf50ed91b943f8e8f96b5efd65489d8303b7a36e2e79834/mkdocs_material-9.7.0-py3-none-any.whl", hash = "sha256:da2866ea53601125ff5baa8aa06404c6e07af3c5ce3d5de95e3b52b80b442887", size = 9283770, upload-time = "2025-11-11T08:49:06.26Z" },
 ]
 
 [[package]]
@@ -661,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "0.30.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -671,9 +665,9 @@ dependencies = [
     { name = "mkdocs-autorefs" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/33/2fa3243439f794e685d3e694590d28469a9b8ea733af4b48c250a3ffc9a0/mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f", size = 106350, upload-time = "2025-09-19T10:49:26.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/13/10bbf9d56565fd91b91e6f5a8cd9b9d8a2b101c4e8ad6eeafa35a706301d/mkdocstrings-1.0.0.tar.gz", hash = "sha256:351a006dbb27aefce241ade110d3cd040c1145b7a3eb5fd5ac23f03ed67f401a", size = 101086, upload-time = "2025-11-27T15:39:40.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82", size = 36704, upload-time = "2025-09-19T10:49:24.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fc/80aa31b79133634721cf7855d37b76ea49773599214896f2ff10be03de2a/mkdocstrings-1.0.0-py3-none-any.whl", hash = "sha256:4c50eb960bff6e05dfc631f6bc00dfabffbcb29c5ff25f676d64daae05ed82fa", size = 35135, upload-time = "2025-11-27T15:39:39.301Z" },
 ]
 
 [package.optional-dependencies]
@@ -683,16 +677,16 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.18.2"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffe" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/ae/58ab2bfbee2792e92a98b97e872f7c003deb903071f75d8d83aa55db28fa/mkdocstrings_python-1.18.2.tar.gz", hash = "sha256:4ad536920a07b6336f50d4c6d5603316fafb1172c5c882370cbbc954770ad323", size = 207972, upload-time = "2025-08-28T16:11:19.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/75/d30af27a2906f00eb90143470272376d728521997800f5dce5b340ba35bc/mkdocstrings_python-2.0.1.tar.gz", hash = "sha256:843a562221e6a471fefdd4b45cc6c22d2607ccbad632879234fa9692e9cf7732", size = 199345, upload-time = "2025-12-03T14:26:11.755Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/8f/ce008599d9adebf33ed144e7736914385e8537f5fc686fdb7cceb8c22431/mkdocstrings_python-1.18.2-py3-none-any.whl", hash = "sha256:944fe6deb8f08f33fa936d538233c4036e9f53e840994f6146e8e94eb71b600d", size = 138215, upload-time = "2025-08-28T16:11:18.176Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/c5f8deba7d2cbdfa7967a716ae801aa9ca5f734b8f54fd473ef77a088dbe/mkdocstrings_python-2.0.1-py3-none-any.whl", hash = "sha256:66ecff45c5f8b71bf174e11d49afc845c2dfc7fc0ab17a86b6b337e0f24d8d90", size = 105055, upload-time = "2025-12-03T14:26:10.184Z" },
 ]
 
 [[package]]
@@ -733,11 +727,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.5.0"
+version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -872,15 +866,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.16.1"
+version = "10.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/6d/af5378dbdb379fddd9a277f8b9888c027db480cde70028669ebd009d642a/pymdown_extensions-10.17.2.tar.gz", hash = "sha256:26bb3d7688e651606260c90fb46409fbda70bf9fdc3623c7868643a1aeee4713", size = 847344, upload-time = "2025-11-26T15:43:57.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/93/78/b93cb80bd673bdc9f6ede63d8eb5b4646366953df15667eb3603be57a2b1/pymdown_extensions-10.17.2-py3-none-any.whl", hash = "sha256:bffae79a2e8b9e44aef0d813583a8fea63457b7a23643a43988055b7b79b4992", size = 266556, upload-time = "2025-11-26T15:43:55.162Z" },
 ]
 
 [[package]]
@@ -898,7 +892,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -907,22 +901,22 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -962,15 +956,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -1057,28 +1042,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.2"
+version = "0.14.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/34/8218a19b2055b80601e8fd201ec723c74c7fe1ca06d525a43ed07b6d8e85/ruff-0.14.2.tar.gz", hash = "sha256:98da787668f239313d9c902ca7c523fe11b8ec3f39345553a51b25abc4629c96", size = 5539663, upload-time = "2025-10-23T19:37:00.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/d9/f7a0c4b3a2bf2556cd5d99b05372c29980249ef71e8e32669ba77428c82c/ruff-0.14.8.tar.gz", hash = "sha256:774ed0dd87d6ce925e3b8496feb3a00ac564bea52b9feb551ecd17e0a23d1eed", size = 5765385, upload-time = "2025-12-04T15:06:17.669Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/dd/23eb2db5ad9acae7c845700493b72d3ae214dce0b226f27df89216110f2b/ruff-0.14.2-py3-none-linux_armv6l.whl", hash = "sha256:7cbe4e593505bdec5884c2d0a4d791a90301bc23e49a6b1eb642dd85ef9c64f1", size = 12533390, upload-time = "2025-10-23T19:36:18.044Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/8c/5f9acff43ddcf3f85130d0146d0477e28ccecc495f9f684f8f7119b74c0d/ruff-0.14.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8d54b561729cee92f8d89c316ad7a3f9705533f5903b042399b6ae0ddfc62e11", size = 12887187, upload-time = "2025-10-23T19:36:22.664Z" },
-    { url = "https://files.pythonhosted.org/packages/99/fa/047646491479074029665022e9f3dc6f0515797f40a4b6014ea8474c539d/ruff-0.14.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5c8753dfa44ebb2cde10ce5b4d2ef55a41fb9d9b16732a2c5df64620dbda44a3", size = 11925177, upload-time = "2025-10-23T19:36:24.778Z" },
-    { url = "https://files.pythonhosted.org/packages/15/8b/c44cf7fe6e59ab24a9d939493a11030b503bdc2a16622cede8b7b1df0114/ruff-0.14.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d0bbeffb8d9f4fccf7b5198d566d0bad99a9cb622f1fc3467af96cb8773c9e3", size = 12358285, upload-time = "2025-10-23T19:36:26.979Z" },
-    { url = "https://files.pythonhosted.org/packages/45/01/47701b26254267ef40369aea3acb62a7b23e921c27372d127e0f3af48092/ruff-0.14.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7047f0c5a713a401e43a88d36843d9c83a19c584e63d664474675620aaa634a8", size = 12303832, upload-time = "2025-10-23T19:36:29.192Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5c/ae7244ca4fbdf2bee9d6405dcd5bc6ae51ee1df66eb7a9884b77b8af856d/ruff-0.14.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bf8d2f9aa1602599217d82e8e0af7fd33e5878c4d98f37906b7c93f46f9a839", size = 13036995, upload-time = "2025-10-23T19:36:31.861Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4c/0860a79ce6fd4c709ac01173f76f929d53f59748d0dcdd662519835dae43/ruff-0.14.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1c505b389e19c57a317cf4b42db824e2fca96ffb3d86766c1c9f8b96d32048a7", size = 14512649, upload-time = "2025-10-23T19:36:33.915Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/7f/d365de998069720a3abfc250ddd876fc4b81a403a766c74ff9bde15b5378/ruff-0.14.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a307fc45ebd887b3f26b36d9326bb70bf69b01561950cdcc6c0bdf7bb8e0f7cc", size = 14088182, upload-time = "2025-10-23T19:36:36.983Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/ea/d8e3e6b209162000a7be1faa41b0a0c16a133010311edc3329753cc6596a/ruff-0.14.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61ae91a32c853172f832c2f40bd05fd69f491db7289fb85a9b941ebdd549781a", size = 13599516, upload-time = "2025-10-23T19:36:39.208Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ea/c7810322086db68989fb20a8d5221dd3b79e49e396b01badca07b433ab45/ruff-0.14.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1967e40286f63ee23c615e8e7e98098dedc7301568bd88991f6e544d8ae096", size = 13272690, upload-time = "2025-10-23T19:36:41.453Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/39/10b05acf8c45786ef501d454e00937e1b97964f846bf28883d1f9619928a/ruff-0.14.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2877f02119cdebf52a632d743a2e302dea422bfae152ebe2f193d3285a3a65df", size = 13496497, upload-time = "2025-10-23T19:36:43.61Z" },
-    { url = "https://files.pythonhosted.org/packages/59/a1/1f25f8301e13751c30895092485fada29076e5e14264bdacc37202e85d24/ruff-0.14.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e681c5bc777de5af898decdcb6ba3321d0d466f4cb43c3e7cc2c3b4e7b843a05", size = 12266116, upload-time = "2025-10-23T19:36:45.625Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/fa/0029bfc9ce16ae78164e6923ef392e5f173b793b26cc39aa1d8b366cf9dc/ruff-0.14.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e21be42d72e224736f0c992cdb9959a2fa53c7e943b97ef5d081e13170e3ffc5", size = 12281345, upload-time = "2025-10-23T19:36:47.618Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ab/ece7baa3c0f29b7683be868c024f0838770c16607bea6852e46b202f1ff6/ruff-0.14.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b8264016f6f209fac16262882dbebf3f8be1629777cf0f37e7aff071b3e9b92e", size = 12629296, upload-time = "2025-10-23T19:36:49.789Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/7f/638f54b43f3d4e48c6a68062794e5b367ddac778051806b9e235dfb7aa81/ruff-0.14.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ca36b4cb4db3067a3b24444463ceea5565ea78b95fe9a07ca7cb7fd16948770", size = 13371610, upload-time = "2025-10-23T19:36:51.882Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/35/3654a973ebe5b32e1fd4a08ed2d46755af7267da7ac710d97420d7b8657d/ruff-0.14.2-py3-none-win32.whl", hash = "sha256:41775927d287685e08f48d8eb3f765625ab0b7042cc9377e20e64f4eb0056ee9", size = 12415318, upload-time = "2025-10-23T19:36:53.961Z" },
-    { url = "https://files.pythonhosted.org/packages/71/30/3758bcf9e0b6a4193a6f51abf84254aba00887dfa8c20aba18aa366c5f57/ruff-0.14.2-py3-none-win_amd64.whl", hash = "sha256:0df3424aa5c3c08b34ed8ce099df1021e3adaca6e90229273496b839e5a7e1af", size = 13565279, upload-time = "2025-10-23T19:36:56.578Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/5d/aa883766f8ef9ffbe6aa24f7192fb71632f31a30e77eb39aa2b0dc4290ac/ruff-0.14.2-py3-none-win_arm64.whl", hash = "sha256:ea9d635e83ba21569fbacda7e78afbfeb94911c9434aff06192d9bc23fd5495a", size = 12554956, upload-time = "2025-10-23T19:36:58.714Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b8/9537b52010134b1d2b72870cc3f92d5fb759394094741b09ceccae183fbe/ruff-0.14.8-py3-none-linux_armv6l.whl", hash = "sha256:ec071e9c82eca417f6111fd39f7043acb53cd3fde9b1f95bbed745962e345afb", size = 13441540, upload-time = "2025-12-04T15:06:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/24/00/99031684efb025829713682012b6dd37279b1f695ed1b01725f85fd94b38/ruff-0.14.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8cdb162a7159f4ca36ce980a18c43d8f036966e7f73f866ac8f493b75e0c27e9", size = 13669384, upload-time = "2025-12-04T15:06:51.809Z" },
+    { url = "https://files.pythonhosted.org/packages/72/64/3eb5949169fc19c50c04f28ece2c189d3b6edd57e5b533649dae6ca484fe/ruff-0.14.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e2fcbefe91f9fad0916850edf0854530c15bd1926b6b779de47e9ab619ea38f", size = 12806917, upload-time = "2025-12-04T15:06:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/5250babb0b1b11910f470370ec0cbc67470231f7cdc033cee57d4976f941/ruff-0.14.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9d70721066a296f45786ec31916dc287b44040f553da21564de0ab4d45a869b", size = 13256112, upload-time = "2025-12-04T15:06:23.498Z" },
+    { url = "https://files.pythonhosted.org/packages/78/4c/6c588e97a8e8c2d4b522c31a579e1df2b4d003eddfbe23d1f262b1a431ff/ruff-0.14.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c87e09b3cd9d126fc67a9ecd3b5b1d3ded2b9c7fce3f16e315346b9d05cfb52", size = 13227559, upload-time = "2025-12-04T15:06:33.432Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ce/5f78cea13eda8eceac71b5f6fa6e9223df9b87bb2c1891c166d1f0dce9f1/ruff-0.14.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d62cb310c4fbcb9ee4ac023fe17f984ae1e12b8a4a02e3d21489f9a2a5f730c", size = 13896379, upload-time = "2025-12-04T15:06:02.687Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/79/13de4517c4dadce9218a20035b21212a4c180e009507731f0d3b3f5df85a/ruff-0.14.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1af35c2d62633d4da0521178e8a2641c636d2a7153da0bac1b30cfd4ccd91344", size = 15372786, upload-time = "2025-12-04T15:06:29.828Z" },
+    { url = "https://files.pythonhosted.org/packages/00/06/33df72b3bb42be8a1c3815fd4fae83fa2945fc725a25d87ba3e42d1cc108/ruff-0.14.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25add4575ffecc53d60eed3f24b1e934493631b48ebbc6ebaf9d8517924aca4b", size = 14990029, upload-time = "2025-12-04T15:06:36.812Z" },
+    { url = "https://files.pythonhosted.org/packages/64/61/0f34927bd90925880394de0e081ce1afab66d7b3525336f5771dcf0cb46c/ruff-0.14.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c943d847b7f02f7db4201a0600ea7d244d8a404fbb639b439e987edcf2baf9a", size = 14407037, upload-time = "2025-12-04T15:06:39.979Z" },
+    { url = "https://files.pythonhosted.org/packages/96/bc/058fe0aefc0fbf0d19614cb6d1a3e2c048f7dc77ca64957f33b12cfdc5ef/ruff-0.14.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb6e8bf7b4f627548daa1b69283dac5a296bfe9ce856703b03130732e20ddfe2", size = 14102390, upload-time = "2025-12-04T15:06:46.372Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/e4f77b02b804546f4c17e8b37a524c27012dd6ff05855d2243b49a7d3cb9/ruff-0.14.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:7aaf2974f378e6b01d1e257c6948207aec6a9b5ba53fab23d0182efb887a0e4a", size = 14230793, upload-time = "2025-12-04T15:06:20.497Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/52/bb8c02373f79552e8d087cedaffad76b8892033d2876c2498a2582f09dcf/ruff-0.14.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e5758ca513c43ad8a4ef13f0f081f80f08008f410790f3611a21a92421ab045b", size = 13160039, upload-time = "2025-12-04T15:06:49.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ad/b69d6962e477842e25c0b11622548df746290cc6d76f9e0f4ed7456c2c31/ruff-0.14.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f74f7ba163b6e85a8d81a590363bf71618847e5078d90827749bfda1d88c9cdf", size = 13205158, upload-time = "2025-12-04T15:06:54.574Z" },
+    { url = "https://files.pythonhosted.org/packages/06/63/54f23da1315c0b3dfc1bc03fbc34e10378918a20c0b0f086418734e57e74/ruff-0.14.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:eed28f6fafcc9591994c42254f5a5c5ca40e69a30721d2ab18bb0bb3baac3ab6", size = 13469550, upload-time = "2025-12-04T15:05:59.209Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7d/a4d7b1961e4903bc37fffb7ddcfaa7beb250f67d97cfd1ee1d5cddb1ec90/ruff-0.14.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:21d48fa744c9d1cb8d71eb0a740c4dd02751a5de9db9a730a8ef75ca34cf138e", size = 14211332, upload-time = "2025-12-04T15:06:06.027Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/93/2a5063341fa17054e5c86582136e9895db773e3c2ffb770dde50a09f35f0/ruff-0.14.8-py3-none-win32.whl", hash = "sha256:15f04cb45c051159baebb0f0037f404f1dc2f15a927418f29730f411a79bc4e7", size = 13151890, upload-time = "2025-12-04T15:06:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1c/65c61a0859c0add13a3e1cbb6024b42de587456a43006ca2d4fd3d1618fe/ruff-0.14.8-py3-none-win_amd64.whl", hash = "sha256:9eeb0b24242b5bbff3011409a739929f497f3fb5fe3b5698aba5e77e8c833097", size = 14537826, upload-time = "2025-12-04T15:06:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/63/8b41cea3afd7f58eb64ac9251668ee0073789a3bc9ac6f816c8c6fef986d/ruff-0.14.8-py3-none-win_arm64.whl", hash = "sha256:965a582c93c63fe715fd3e3f8aa37c4b776777203d8e1d8aa3cc0c14424a4b99", size = 13634522, upload-time = "2025-12-04T15:06:43.212Z" },
 ]
 
 [[package]]
@@ -1168,11 +1153,11 @@ wheels = [
 
 [[package]]
 name = "trove-classifiers"
-version = "2025.9.11.17"
+version = "2025.12.1.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/9a/778622bc06632529817c3c524c82749a112603ae2bbcf72ee3eb33a2c4f1/trove_classifiers-2025.9.11.17.tar.gz", hash = "sha256:931ca9841a5e9c9408bc2ae67b50d28acf85bef56219b56860876dd1f2d024dd", size = 16975, upload-time = "2025-09-11T17:07:50.97Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/e1/000add3b3e0725ce7ee0ea6ea4543f1e1d9519742f3b2320de41eeefa7c7/trove_classifiers-2025.12.1.14.tar.gz", hash = "sha256:a74f0400524fc83620a9be74a07074b5cbe7594fd4d97fd4c2bfde625fdc1633", size = 16985, upload-time = "2025-12-01T14:47:11.456Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/85/a4ff8758c66f1fc32aa5e9a145908394bf9cf1c79ffd1113cfdeb77e74e4/trove_classifiers-2025.9.11.17-py3-none-any.whl", hash = "sha256:5d392f2d244deb1866556457d6f3516792124a23d1c3a463a2e8668a5d1c15dd", size = 14158, upload-time = "2025-09-11T17:07:49.886Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7e/bc19996fa86cad8801e8ffe6f1bba5836ca0160df76d0410d27432193712/trove_classifiers-2025.12.1.14-py3-none-any.whl", hash = "sha256:a8206978ede95937b9959c3aff3eb258bbf7b07dff391ddd4ea7e61f316635ab", size = 14184, upload-time = "2025-12-01T14:47:10.113Z" },
 ]
 
 [[package]]
@@ -1197,12 +1182,21 @@ wheels = [
 ]
 
 [[package]]
-name = "urllib3"
-version = "2.5.0"
+name = "tzdata"
+version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/43/554c2569b62f49350597348fc3ac70f786e3c32e7f19d266e19817812dd3/urllib3-2.6.0.tar.gz", hash = "sha256:cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1", size = 432585, upload-time = "2025-12-05T15:08:47.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/1a/9ffe814d317c5224166b23e7c47f606d6e473712a2fad0f704ea9b99f246/urllib3-2.6.0-py3-none-any.whl", hash = "sha256:c90f7a39f716c572c4e3e58509581ebd83f9b59cced005b7db7ad2d22b0db99f", size = 131083, upload-time = "2025-12-05T15:08:45.983Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements comprehensive support for LIFX Ceiling products (176/177/201/202) with semantic control over uplight and downlight components while maintaining full backward compatibility with MatrixLight API.

Key Features:
- Independent uplight and downlight component control with smart brightness logic
- Optional state persistence via JSON file storage for component states
- Automatic product detection in discovery with CeilingLight instantiation
- Enhanced MatrixLight.get_all_tile_colors() to support >64 zones (16x8 Capsule)

New Components:
- CeilingLight class: Extends MatrixLight with component-aware methods
  - set_uplight_color() / set_downlight_colors()
  - turn_uplight_on/off() / turn_downlight_on/off()
  - get_uplight_color() / get_downlight_colors()
  - uplight_is_on / downlight_is_on properties
  - Priority-based brightness determination (stored → inferred → default)
- Product quirks module: Component layout metadata (uplight_zone, downlight_zones)
- Comprehensive test suite with component control and state persistence tests

Technical Details:
- Uplight: Single zone for ambient lighting (zone 63 for 8x8, zone 127 for 16x8)
- Downlight: Multiple zones for main illumination (0-62 for 8x8, 0-126 for 16x8)
- MatrixLight enhancement: Multi-request handling for tiles with >64 zones
- Discovery integration: Product ID-based detection before generic MatrixLight
- State persistence: Optional JSON file storage with device serial key

Supported Products:
- Product 176: Ceiling (US) - 8x8 matrix
- Product 177: Ceiling (Intl) - 8x8 matrix
- Product 201: Ceiling 26x13" (US) - 16x8 matrix
- Product 202: Ceiling 26x13" (Intl) - 16x8 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)