### PR TITLE
feat(devices): add fast parameter to set_extended_color_zones()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,22 @@ async with await MultiZoneLight.from_ip("192.168.1.100") as light:
 - `get_extended_color_zones(start, end)`: Direct access to extended multizone protocol (requires extended capability)
 - `get_color_zones(start, end)`: Direct access to standard multizone protocol (works on all multizone devices)
 
+**Fire-and-forget mode for animations:**
+
+For high-frequency animations (>20 updates/second), use the `fast=True` parameter to skip waiting for device acknowledgement:
+
+```python
+# Standard mode (waits for response)
+await light.set_extended_color_zones(0, colors)
+
+# Fast mode for animations (fire-and-forget, no response waiting)
+for frame in animation_frames:
+    await light.set_extended_color_zones(0, frame, fast=True)
+    await asyncio.sleep(0.033)  # ~30 FPS
+```
+
+**Note:** `MatrixLight.set64()` is already fire-and-forget by default.
+
 ### Packet Flow
 
 1. Create packet instance (e.g., `LightSetColor`)


### PR DESCRIPTION
Add fire-and-forget mode for high-frequency animations (>20 updates/second) where waiting for device acknowledgement creates unacceptable latency.

When fast=True:
- Sends packet with ack_required=False and res_required=False
- Does not wait for device response
- Ideal for smooth animations at 30+ FPS

Note: MatrixLight.set64() is already fire-and-forget by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)