### PR TITLE
fix(devices): add length parameter to copy_frame_buffer()

### DIFF
--- a/src/lifx/devices/matrix.py
+++ b/src/lifx/devices/matrix.py
@@ -699,6 +699,7 @@ class MatrixLight(Light):
         source_fb: int = 1,
         target_fb: int = 0,
         duration: float = 0.0,
+        length: int = 1,
     ) -> None:
         """Copy frame buffer (for tiles with >64 zones).
 
@@ -710,6 +711,7 @@ class MatrixLight(Light):
             source_fb: Source frame buffer index (usually 1)
             target_fb: Target frame buffer index (usually 0)
             duration: time in seconds to transition if target_fb is 0
+            length: Number of tiles to update starting from tile_index (default 1)
 
         Example:
             >>> # For 16x8 tile (128 zones):
@@ -739,12 +741,18 @@ class MatrixLight(Light):
             >>> await matrix.copy_frame_buffer(
             ...     tile_index=0, source_fb=1, target_fb=0, duration=2.0
             ... )
+
+            >>> # For a chain of 5 tiles, update all simultaneously:
+            >>> await matrix.copy_frame_buffer(
+            ...     tile_index=0, source_fb=1, target_fb=0, length=5
+            ... )
         """
         _LOGGER.debug(
-            "Copying frame buffer %d -> %d for tile %d on %s",
+            "Copying frame buffer %d -> %d for tile %d (length=%d) on %s",
             source_fb,
             target_fb,
             tile_index,
+            length,
             self.label or self.serial,
         )
 
@@ -761,7 +769,7 @@ class MatrixLight(Light):
         await self.connection.send_packet(
             packets.Tile.CopyFrameBuffer(
                 tile_index=tile_index,
-                length=1,
+                length=length,
                 src_fb_index=source_fb,
                 dst_fb_index=target_fb,
                 src_x=0,

--- a/tests/test_devices/test_matrix.py
+++ b/tests/test_devices/test_matrix.py
@@ -373,6 +373,37 @@ class TestMatrixLight:
             assert copied_colors[0].saturation == 1.0
             assert copied_colors[0].brightness == 1.0
 
+    async def test_copy_frame_buffer_with_length(self, emulator_devices) -> None:
+        """Test copy_frame_buffer() with explicit length parameter."""
+        matrix = emulator_devices[6]
+        async with matrix:
+            chain = await matrix.get_device_chain()
+            tile = chain[0]
+
+            # Set pattern on temp buffer (fb_index=1)
+            blue_colors = [Colors.BLUE] * 64
+            await matrix.set64(
+                tile_index=0,
+                length=1,
+                x=0,
+                y=0,
+                width=tile.width,
+                duration=0,
+                colors=blue_colors,
+                fb_index=1,
+            )
+
+            # Copy with explicit length=1 (same as default behavior)
+            await matrix.copy_frame_buffer(
+                tile_index=0, source_fb=1, target_fb=0, length=1
+            )
+
+            # Verify the copy worked
+            copied_colors = await matrix.get64()
+            assert copied_colors[0].hue == 240  # Blue
+            assert copied_colors[0].saturation == 1.0
+            assert copied_colors[0].brightness == 1.0
+
     async def test_set_effect_without_palette(self, emulator_devices) -> None:
         """Test setting effect without a palette (palette_count=0)."""
         matrix = emulator_devices[6]


### PR DESCRIPTION
Allow users to specify the number of tiles to update when copying frame buffers, enabling simultaneous updates for devices with multiple tiles in their chain.

The parameter defaults to 1 for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)