### PR TITLE
docs(api): add dataclass documentation and improve navigation

### DIFF
--- a/docs/api/devices.md
+++ b/docs/api/devices.md
@@ -3,6 +3,87 @@
 Device classes provide direct control over LIFX devices. All device classes support async context
 managers for automatic resource cleanup.
 
+## State and Info Classes
+
+Device state and information dataclasses returned by device methods.
+
+### DeviceState
+
+Base device state dataclass returned by `Device.state`.
+
+::: lifx.devices.base.DeviceState
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### DeviceVersion
+
+Device version information returned by `Device.get_version()`.
+
+::: lifx.devices.base.DeviceVersion
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### DeviceInfo
+
+Device runtime information returned by `Device.get_info()`.
+
+::: lifx.devices.base.DeviceInfo
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### WifiInfo
+
+WiFi module information returned by `Device.get_wifi_info()`.
+
+::: lifx.devices.base.WifiInfo
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### FirmwareInfo
+
+Firmware version information returned by `Device.get_host_firmware()` and `Device.get_wifi_firmware()`.
+
+::: lifx.devices.base.FirmwareInfo
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### CollectionInfo
+
+Location and group collection information returned by `Device.get_location()` and `Device.get_group()`.
+
+::: lifx.devices.base.CollectionInfo
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### DeviceCapabilities
+
+Device capabilities from product registry, available via `Device.capabilities`.
+
+::: lifx.devices.base.DeviceCapabilities
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
 ## Base Device
 
 The `Device` class provides common operations available on all LIFX devices.
@@ -29,6 +110,17 @@ The `Light` class provides color control and effects for standard LIFX lights.
       filters:
         - "!^_"
 
+### LightState
+
+Light device state dataclass returned by `Light.state`.
+
+::: lifx.devices.light.LightState
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
 ## HEV Light
 
 The `HevLight` class extends `Light` with anti-bacterial cleaning cycle control for LIFX HEV devices.
@@ -41,6 +133,17 @@ The `HevLight` class extends `Light` with anti-bacterial cleaning cycle control 
       show_if_no_docstring: false
       filters:
         - "!^_"
+
+### HevLightState
+
+HEV light device state dataclass returned by `HevLight.state`.
+
+::: lifx.devices.hev.HevLightState
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
 
 ## Infrared Light
 
@@ -55,6 +158,17 @@ The `InfraredLight` class extends `Light` with infrared LED control for night vi
       filters:
         - "!^_"
 
+### InfraredLightState
+
+Infrared light device state dataclass returned by `InfraredLight.state`.
+
+::: lifx.devices.infrared.InfraredLightState
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
 ## MultiZone Light
 
 The `MultiZoneLight` class controls LIFX strips and beams with multiple color zones.
@@ -68,6 +182,30 @@ The `MultiZoneLight` class controls LIFX strips and beams with multiple color zo
       filters:
         - "!^_"
 
+### MultiZoneLightState
+
+MultiZone light device state dataclass returned by `MultiZoneLight.state`.
+
+::: lifx.devices.multizone.MultiZoneLightState
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### MultiZoneEffect
+
+Configuration dataclass for multizone effects (MOVE). Used with `MultiZoneLight.set_effect()` and returned by `MultiZoneLight.get_effect()`.
+
+::: lifx.devices.multizone.MultiZoneEffect
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+      filters:
+        - "!^_"
+
 ## Matrix Light
 
 The `MatrixLight` class controls LIFX matrix devices (tiles, candle, path) with 2D zone control.
@@ -76,6 +214,43 @@ The `MatrixLight` class controls LIFX matrix devices (tiles, candle, path) with 
     options:
       show_root_heading: true
       heading_level: 3
+      members_order: source
+      show_if_no_docstring: false
+      filters:
+        - "!^_"
+
+### MatrixLightState
+
+Matrix light device state dataclass returned by `MatrixLight.state`.
+
+::: lifx.devices.matrix.MatrixLightState
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### TileInfo
+
+Information dataclass for a single tile in the device chain. Returned as part of `MatrixLightState.chain`.
+
+::: lifx.devices.matrix.TileInfo
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+      filters:
+        - "!^_"
+
+### MatrixEffect
+
+Configuration dataclass for matrix effects (MORPH, FLAME, SKY). Used with `MatrixLight.set_effect()` and returned by `MatrixLight.get_effect()`.
+
+::: lifx.devices.matrix.MatrixEffect
+    options:
+      show_root_heading: true
+      heading_level: 4
       members_order: source
       show_if_no_docstring: false
       filters:

--- a/docs/api/high-level.md
+++ b/docs/api/high-level.md
@@ -34,6 +34,32 @@ recommended entry points for most users.
       members_order: source
       show_if_no_docstring: false
 
+## Organizational Groupings
+
+Dataclasses for organizing devices by location or group. Returned by `DeviceGroup.organize_by_location()` and `DeviceGroup.organize_by_group()`.
+
+### LocationGrouping
+
+Location-based device grouping returned by `DeviceGroup.organize_by_location()`.
+
+::: lifx.api.LocationGrouping
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
+### GroupGrouping
+
+Group-based device grouping returned by `DeviceGroup.organize_by_group()`.
+
+::: lifx.api.GroupGrouping
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
 ## Examples
 
 ### Simple Discovery

--- a/docs/api/network.md
+++ b/docs/api/network.md
@@ -18,6 +18,17 @@ Functions for discovering LIFX devices on the local network.
       heading_level: 3
       members_order: source
 
+### DiscoveryResponse
+
+Response dataclass from custom discovery broadcasts (using packets other than GetService).
+
+::: lifx.network.discovery.DiscoveryResponse
+    options:
+      show_root_heading: true
+      heading_level: 4
+      members_order: source
+      show_if_no_docstring: false
+
 ## UDP Transport
 
 Low-level UDP transport for sending and receiving LIFX protocol messages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,19 +25,16 @@ theme:
       icon: material/brightness-4
       name: Switch to light mode
   features:
-  - navigation.instant
   - navigation.tracking
   - navigation.tabs
   - navigation.tabs.sticky
   - navigation.sections
-  - navigation.expand
   - navigation.path
   - navigation.indexes
+  - navigation.top
   - toc.follow
-  - toc.integrate
   - search.suggest
   - search.highlight
-  - search.share
   - content.code.copy
   - content.code.annotate
   - content.tabs.link


### PR DESCRIPTION
Add API documentation for state and info dataclasses:
- Device layer: DeviceState, DeviceVersion, DeviceInfo, WifiInfo, FirmwareInfo, CollectionInfo, DeviceCapabilities
- Light types: LightState, HevLightState, InfraredLightState
- MultiZone: MultiZoneLightState, MultiZoneEffect
- Matrix: MatrixLightState, TileInfo, MatrixEffect
- High-level API: LocationGrouping, GroupGrouping
- Network: DiscoveryResponse

Adjust mkdocs navigation features for better UX:
- Remove instant loading (can cause issues with large docs)
- Add back-to-top navigation button
- Simplify TOC and search features

🤖 Generated with [Claude Code](https://claude.com/claude-code)