### PR TITLE
fix(api): close device connections in DeviceGroup context manager

### DIFF
--- a/src/lifx/api.py
+++ b/src/lifx/api.py
@@ -126,8 +126,9 @@ class DeviceGroup:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Exit async context manager."""
-        pass
+        """Exit async context manager and close all device connections."""
+        for device in self._devices:
+            await device.connection.close()
 
     def __iter__(
         self,

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -23,15 +23,12 @@ import logging
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from lifx.color import HSBK
 from lifx.devices.matrix import MatrixLight, MatrixLightState
 from lifx.exceptions import LifxError
 from lifx.products import get_ceiling_layout, is_ceiling_product
-
-if TYPE_CHECKING:
-    pass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_devices/test_state_hev.py
+++ b/tests/test_devices/test_state_hev.py
@@ -217,6 +217,7 @@ class TestHevLightStateManagement:
         assert hev_light._state is None
         await hev_light.refresh_state()  # type: ignore
         assert isinstance(hev_light.state, HevLightState)
+        await hev_light.close()
 
 
 class TestHevAcknowledgementBasedStateUpdates:

--- a/tests/test_devices/test_state_infrared.py
+++ b/tests/test_devices/test_state_infrared.py
@@ -149,6 +149,7 @@ class TestInfraredLightStateManagement:
         assert infrared_light._state is None
         await infrared_light.refresh_state()  # type: ignore
         assert isinstance(infrared_light.state, InfraredLightState)
+        await infrared_light.close()
 
 
 class TestInfraredAcknowledgementBasedStateUpdates:


### PR DESCRIPTION
- DeviceGroup.__aexit__ now properly closes all device connections
- Fixes ResourceWarning about unclosed sockets/transports in tests
- Remove unused TYPE_CHECKING import and empty block in ceiling.py
- Add missing close() calls in state management tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)