### PR TITLE
test: fix flaky tests on Windows and macOS CI runners

### DIFF
--- a/tests/test_network/test_connection.py
+++ b/tests/test_network/test_connection.py
@@ -169,8 +169,10 @@ class TestDeviceConnection:
 
             # If truly concurrent, total time should be ~0.1s (one sleep duration)
             # If serialized, it would be ~0.2s (two sleep durations)
-            # Allow some overhead, but verify concurrency
-            assert total_time < 0.15, (
+            # Use generous tolerance (0.19s) to account for CI variability
+            # (especially on macOS where timing can be less precise under load)
+            # Anything under 0.2s proves concurrency since serial would be >= 0.2s
+            assert total_time < 0.19, (
                 f"Requests took too long ({total_time}s), suggesting serialization"
             )
 

--- a/tests/test_theme/test_canvas.py
+++ b/tests/test_theme/test_canvas.py
@@ -122,9 +122,11 @@ class TestShufflePoints:
     def test_shuffle_preserves_point_count(self) -> None:
         """Test that shuffle_points preserves number of points."""
         canvas = Canvas()
+        # Use points spaced far apart (10 units) to avoid collision after shuffle.
+        # shuffle_point() moves each point by ±3, so points 7+ apart can't collide.
         canvas[(0, 0)] = Colors.RED
-        canvas[(5, 5)] = Colors.GREEN
-        canvas[(10, 10)] = Colors.BLUE
+        canvas[(10, 10)] = Colors.GREEN
+        canvas[(20, 20)] = Colors.BLUE
 
         original_count = len(canvas.points)
         canvas.shuffle_points()


### PR DESCRIPTION
Replace timing-sensitive assertions with polling-based approaches:
- Add wait_for_mock_called() helper for effect tests
- Add wait_for_effect_complete() helper for effect completion tests
- Use polling in test_pulse_effect_strobe_mode instead of 20ms sleep
- Use polling in test_effect_completion_restores_state instead of 500ms sleep

Fix timing tolerance issues:
- Increase concurrent connection test threshold from 0.15s to 0.19s to account for CI variability on macOS

Fix random collision in shuffle test:
- Space canvas points 10 units apart (was 5) to prevent collision since shuffle_point() moves points by ±3

These tests were failing intermittently due to:
- Windows ProactorEventLoop having slower task scheduling
- CI runners under load having variable timing
- Random coordinate overlap in shuffle test

🤖 Generated with [Claude Code](https://claude.com/claude-code)