### PR TITLE
feat(network): add mDNS/DNS-SD discovery for LIFX devices

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -20,9 +20,14 @@ lifx/
 │   └── matrix.py            # MatrixLight (2D matrix devices: tiles, candle, path)
 ├── network/                  # Network layer
 │   ├── connection.py        # Device connections with lazy opening
-│   ├── discovery.py         # Network device discovery
+│   ├── discovery.py         # Network device discovery (UDP broadcast)
 │   ├── message.py           # Message building and parsing
-│   └── transport.py         # UDP transport
+│   ├── transport.py         # UDP transport
+│   └── mdns/                # mDNS/DNS-SD discovery
+│       ├── discovery.py     # mDNS discovery functions
+│       ├── dns.py           # DNS wire format parser
+│       ├── transport.py     # Multicast UDP transport
+│       └── types.py         # LifxServiceRecord dataclass
 ├── products/                 # Product registry
 │   ├── registry.py          # Auto-generated product database
 │   ├── generator.py         # Generator to download/parse products.json
@@ -43,7 +48,8 @@ lifx/
 
 Main entry points for most users:
 
-- [`discover()`](high-level.md#lifx.api.discover) - Simple device discovery
+- [`discover()`](high-level.md#lifx.api.discover) - Device discovery via UDP broadcast
+- [`discover_mdns()`](high-level.md#lifx.api.discover_mdns) - Device discovery via mDNS (faster)
 - [`find_by_serial()`](high-level.md#lifx.api.find_by_serial) - Find device by serial number
 - [`find_by_label()`](high-level.md#lifx.api.find_by_label) - Find devices by label (exact or substring)
 - [`find_by_ip()`](high-level.md#lifx.api.find_by_ip) - Find device by IP address
@@ -71,7 +77,9 @@ Work with colors:
 
 Low-level network operations:
 
-- [`discover_devices()`](network.md#lifx.network.discovery.discover_devices) - Low-level discovery
+- [`discover_devices()`](network.md#lifx.network.discovery.discover_devices) - Low-level UDP discovery
+- [`discover_lifx_services()`](network.md#lifx.network.mdns.discover_lifx_services) - Low-level mDNS discovery
+- [`LifxServiceRecord`](network.md#lifx.network.mdns.LifxServiceRecord) - mDNS service record
 - [`DeviceConnection`](network.md#lifx.network.connection.DeviceConnection) - Device connections
 
 ### Products Registry

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -24,6 +24,27 @@ async def main():
 asyncio.run(main())
 ```
 
+**Alternative: mDNS Discovery**
+
+For faster discovery with device type detection in a single query:
+
+```python
+import asyncio
+from lifx import discover_mdns
+
+
+async def main():
+    async for device in discover_mdns():
+        async with device:
+            color, power, label = await device.get_color()
+            print(f"{label}: {type(device).__name__}")
+
+
+asyncio.run(main())
+```
+
+mDNS discovery is faster because it gets device type information directly from the mDNS response, eliminating extra network queries.
+
 ### 2. Control a Light
 
 Turn on the first discovered light, then change its color:

--- a/docs/user-guide/advanced-usage.md
+++ b/docs/user-guide/advanced-usage.md
@@ -4,6 +4,7 @@ This guide covers advanced lifx patterns and techniques for building robust LIFX
 
 ## Table of Contents
 
+- [Discovery Methods](#discovery-methods)
 - [Storing State](#storing-state)
 - [Connection Management](#connection-management)
 - [Concurrency Patterns](#concurrency-patterns)
@@ -11,6 +12,76 @@ This guide covers advanced lifx patterns and techniques for building robust LIFX
 - [Device Capabilities](#device-capabilities)
 - [Custom Effects](#custom-effects)
 - [Performance Optimization](#performance-optimization)
+
+## Discovery Methods
+
+lifx-async provides two discovery methods with different trade-offs:
+
+### UDP Broadcast Discovery
+
+The traditional discovery method broadcasts to all devices on the network:
+
+```python
+from lifx import discover
+
+async def broadcast_discovery():
+    async for device in discover(timeout=5.0):
+        async with device:
+            color, power, label = await device.get_color()
+            print(f"Found: {label} ({type(device).__name__})")
+```
+
+**Characteristics:**
+
+- Sends 1 broadcast + N queries (one per device for type detection)
+- Works on any local network
+- May miss devices on other subnets
+
+### mDNS Discovery
+
+mDNS discovery uses DNS-SD to find devices with a single multicast query:
+
+```python
+from lifx import discover_mdns
+
+async def mdns_discovery():
+    async for device in discover_mdns(timeout=5.0):
+        async with device:
+            color, power, label = await device.get_color()
+            print(f"Found: {label} ({type(device).__name__})")
+```
+
+**Characteristics:**
+
+- Single network query (device type in TXT record)
+- Faster discovery with immediate type detection
+- Can work across subnets with an mDNS reflector
+- Zero dependencies (uses Python stdlib only)
+
+### Low-Level mDNS API
+
+For raw mDNS data without device instantiation:
+
+```python
+from lifx import discover_lifx_services
+
+async def raw_mdns_discovery():
+    async for record in discover_lifx_services(timeout=5.0):
+        print(f"Serial: {record.serial}")
+        print(f"IP: {record.ip}:{record.port}")
+        print(f"Product ID: {record.product_id}")
+        print(f"Firmware: {record.firmware}")
+```
+
+### Choosing a Discovery Method
+
+| Scenario | Recommended Method |
+|----------|-------------------|
+| General use | `discover()` or `discover_mdns()` |
+| Fastest discovery | `discover_mdns()` |
+| Cross-subnet (with reflector) | `discover_mdns()` |
+| Maximum compatibility | `discover()` |
+| Raw device data | `discover_lifx_services()` |
 
 ## Storing State
 

--- a/examples/14_mdns_discovery.py
+++ b/examples/14_mdns_discovery.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Example: Discover LIFX devices using mDNS.
+
+This example demonstrates how to discover LIFX devices on your local network
+using mDNS/DNS-SD instead of UDP broadcast. mDNS discovery has several advantages:
+
+- Single network query (vs 1+N for broadcast discovery)
+- Device type detection without extra queries (from TXT record)
+- Can work across subnets with an mDNS reflector
+
+Usage:
+    uv run python examples/14_mdns_discovery.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import lifx
+
+
+async def discover_with_mdns() -> None:
+    """Discover devices using mDNS and print their info."""
+    print("Discovering LIFX devices via mDNS...")
+    print("-" * 60)
+
+    device_count = 0
+    async for device in lifx.discover_mdns(timeout=5.0):
+        device_count += 1
+        async with device:
+            # get_color() returns color, power, and label in a single request
+            color, power, label = await device.get_color()
+            power_str = "ON" if power > 0 else "OFF"
+
+            print(f"\nDevice #{device_count}")
+            print(f"  Type:   {type(device).__name__}")
+            print(f"  Label:  {label}")
+            print(f"  Serial: {device.serial}")
+            print(f"  IP:     {device.ip}:{device.port}")
+            print(f"  Power:  {power_str}")
+            print(
+                f"  Color:  H={color.hue:.0f} S={color.saturation:.0%} "
+                f"B={color.brightness:.0%} K={color.kelvin}"
+            )
+
+    print("-" * 60)
+    if device_count == 0:
+        print("No devices found. Make sure LIFX devices are on your network.")
+    else:
+        print(f"Found {device_count} device(s)")
+
+
+async def discover_raw_records() -> None:
+    """Discover devices using low-level mDNS API (raw service records)."""
+    print("\nLow-level mDNS discovery (raw service records):")
+    print("-" * 60)
+
+    async for record in lifx.discover_lifx_services(timeout=3.0):
+        print(f"  Serial: {record.serial}")
+        print(f"  IP: {record.ip}:{record.port}")
+        print(f"  Product ID: {record.product_id}")
+        print(f"  Firmware: {record.firmware}")
+        print()
+
+
+async def main() -> None:
+    """Run both discovery methods."""
+    # High-level API - yields device instances (Light, MatrixLight, etc.)
+    await discover_with_mdns()
+
+    # Low-level API - yields raw mDNS service records
+    await discover_raw_records()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/mdns_probe.py
+++ b/scripts/mdns_probe.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""mDNS probe script to discover LIFX devices and dump their service records.
+
+This script sends an mDNS query for _lifx._udp.local and displays all
+responses including PTR, SRV, TXT, and A records.
+
+When --verify is used, it instantiates actual device classes and queries
+them to compare the mDNS 'cnt' field with actual zone/tile counts.
+
+Usage:
+    python scripts/mdns_probe.py [--timeout SECONDS] [--verify]
+
+Requires lifx-async to be installed for product registry and device queries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import socket
+import struct
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+# Try to import lifx for device instantiation and verification
+try:
+    from lifx.devices.base import Device
+    from lifx.devices.ceiling import CeilingLight
+    from lifx.devices.hev import HevLight
+    from lifx.devices.infrared import InfraredLight
+    from lifx.devices.light import Light
+    from lifx.devices.matrix import MatrixLight
+    from lifx.devices.multizone import MultiZoneLight
+    from lifx.products import get_product, is_ceiling_product
+
+    HAVE_LIFX = True
+except ImportError:
+    HAVE_LIFX = False
+    print(
+        "Warning: lifx-async not available - verification disabled",
+        file=sys.stderr,
+    )
+
+# mDNS constants
+MDNS_ADDR = "224.0.0.251"
+MDNS_PORT = 5353
+LIFX_SERVICE = "_lifx._udp.local"
+
+# DNS record types
+DNS_TYPE_A = 1
+DNS_TYPE_PTR = 12
+DNS_TYPE_TXT = 16
+DNS_TYPE_AAAA = 28
+DNS_TYPE_SRV = 33
+DNS_TYPE_ANY = 255
+
+# DNS classes
+DNS_CLASS_IN = 1
+DNS_CLASS_UNIQUE = 0x8001  # Cache flush bit set
+
+TYPE_NAMES = {
+    DNS_TYPE_A: "A",
+    DNS_TYPE_PTR: "PTR",
+    DNS_TYPE_TXT: "TXT",
+    DNS_TYPE_AAAA: "AAAA",
+    DNS_TYPE_SRV: "SRV",
+    DNS_TYPE_ANY: "ANY",
+}
+
+
+@dataclass
+class DNSHeader:
+    """DNS message header (12 bytes)."""
+
+    id: int
+    flags: int
+    qd_count: int  # Question count
+    an_count: int  # Answer count
+    ns_count: int  # Authority count
+    ar_count: int  # Additional count
+
+    @property
+    def is_response(self) -> bool:
+        return bool(self.flags & 0x8000)
+
+    @classmethod
+    def parse(cls, data: bytes) -> DNSHeader:
+        if len(data) < 12:
+            raise ValueError(f"DNS header too short: {len(data)} bytes")
+        id_, flags, qd, an, ns, ar = struct.unpack("!HHHHHH", data[:12])
+        return cls(id_, flags, qd, an, ns, ar)
+
+    def __str__(self) -> str:
+        return (
+            f"DNSHeader(id=0x{self.id:04x}, "
+            f"{'response' if self.is_response else 'query'}, "
+            f"questions={self.qd_count}, answers={self.an_count}, "
+            f"authority={self.ns_count}, additional={self.ar_count})"
+        )
+
+
+@dataclass
+class DNSResourceRecord:
+    """DNS resource record."""
+
+    name: str
+    rtype: int
+    rclass: int
+    ttl: int
+    rdata: bytes
+    parsed_data: Any = None
+
+    @property
+    def type_name(self) -> str:
+        return TYPE_NAMES.get(self.rtype, f"TYPE{self.rtype}")
+
+    def __str__(self) -> str:
+        class_str = (
+            "IN" if (self.rclass & 0x7FFF) == DNS_CLASS_IN else f"CLASS{self.rclass}"
+        )
+        cache_flush = " (cache-flush)" if self.rclass & 0x8000 else ""
+
+        # Format parsed data nicely
+        if self.parsed_data is not None:
+            data_str = str(self.parsed_data)
+        else:
+            data_str = self.rdata.hex()
+
+        type_str = self.type_name
+        return f"{self.name} {self.ttl}s {class_str}{cache_flush} {type_str} {data_str}"
+
+
+@dataclass
+class SRVData:
+    """Parsed SRV record data."""
+
+    priority: int
+    weight: int
+    port: int
+    target: str
+
+    def __str__(self) -> str:
+        return (
+            f"priority={self.priority} weight={self.weight} "
+            f"port={self.port} target={self.target}"
+        )
+
+
+@dataclass
+class TXTData:
+    """Parsed TXT record data."""
+
+    strings: list[str] = field(default_factory=list)
+    pairs: dict[str, str] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        if self.pairs:
+            return " ".join(f"{k}={v}" for k, v in self.pairs.items())
+        return " ".join(repr(s) for s in self.strings)
+
+
+def parse_dns_name(data: bytes, offset: int) -> tuple[str, int]:
+    """Parse a DNS name with compression pointer support.
+
+    Returns (name, new_offset).
+    """
+    labels = []
+    original_offset = offset
+    jumped = False
+    max_jumps = 10  # Prevent infinite loops
+    jumps = 0
+
+    while True:
+        if offset >= len(data):
+            raise ValueError(f"DNS name parsing ran off end of data at offset {offset}")
+
+        length = data[offset]
+
+        # Check for compression pointer (top 2 bits set)
+        if (length & 0xC0) == 0xC0:
+            if offset + 1 >= len(data):
+                raise ValueError("Compression pointer incomplete")
+            # Pointer to earlier in message
+            pointer = ((length & 0x3F) << 8) | data[offset + 1]
+            if not jumped:
+                original_offset = offset + 2
+            jumped = True
+            offset = pointer
+            jumps += 1
+            if jumps > max_jumps:
+                raise ValueError("Too many compression pointer jumps")
+            continue
+
+        offset += 1
+
+        if length == 0:
+            # End of name
+            break
+
+        if offset + length > len(data):
+            raise ValueError(
+                f"Label extends beyond data: offset={offset}, length={length}"
+            )
+
+        label = data[offset : offset + length].decode("utf-8", errors="replace")
+        labels.append(label)
+        offset += length
+
+    name = ".".join(labels) if labels else "."
+    final_offset = original_offset if jumped else offset
+
+    return name, final_offset
+
+
+def parse_resource_record(data: bytes, offset: int) -> tuple[DNSResourceRecord, int]:
+    """Parse a DNS resource record.
+
+    Returns (record, new_offset).
+    """
+    name, offset = parse_dns_name(data, offset)
+
+    if offset + 10 > len(data):
+        raise ValueError(f"Resource record header incomplete at offset {offset}")
+
+    rtype, rclass, ttl, rdlength = struct.unpack("!HHIH", data[offset : offset + 10])
+    offset += 10
+
+    if offset + rdlength > len(data):
+        available = len(data) - offset
+        raise ValueError(
+            f"Resource record data incomplete: need {rdlength}, have {available}"
+        )
+
+    rdata = data[offset : offset + rdlength]
+    offset += rdlength
+
+    # Parse specific record types
+    parsed_data = None
+
+    if rtype == DNS_TYPE_A and rdlength == 4:
+        parsed_data = socket.inet_ntoa(rdata)
+
+    elif rtype == DNS_TYPE_AAAA and rdlength == 16:
+        parsed_data = socket.inet_ntop(socket.AF_INET6, rdata)
+
+    elif rtype == DNS_TYPE_PTR:
+        parsed_data, _ = parse_dns_name(data, offset - rdlength)
+
+    elif rtype == DNS_TYPE_SRV and rdlength >= 6:
+        priority, weight, port = struct.unpack("!HHH", rdata[:6])
+        target, _ = parse_dns_name(data, offset - rdlength + 6)
+        parsed_data = SRVData(priority, weight, port, target)
+
+    elif rtype == DNS_TYPE_TXT:
+        txt_data = TXTData()
+        txt_offset = 0
+        while txt_offset < len(rdata):
+            str_len = rdata[txt_offset]
+            txt_offset += 1
+            if txt_offset + str_len > len(rdata):
+                break
+            txt_str = rdata[txt_offset : txt_offset + str_len].decode(
+                "utf-8", errors="replace"
+            )
+            txt_data.strings.append(txt_str)
+            # Try to parse as key=value
+            if "=" in txt_str:
+                key, _, value = txt_str.partition("=")
+                txt_data.pairs[key] = value
+            txt_offset += str_len
+        parsed_data = txt_data
+
+    return DNSResourceRecord(name, rtype, rclass, ttl, rdata, parsed_data), offset
+
+
+def parse_dns_message(data: bytes) -> tuple[DNSHeader, list[DNSResourceRecord]]:
+    """Parse a complete DNS message.
+
+    Returns (header, list of all resource records).
+    """
+    header = DNSHeader.parse(data)
+    offset = 12
+    records = []
+
+    # Skip questions (we don't need them for responses)
+    for _ in range(header.qd_count):
+        _, offset = parse_dns_name(data, offset)
+        offset += 4  # QTYPE + QCLASS
+
+    # Parse all resource records (answers, authority, additional)
+    total_records = header.an_count + header.ns_count + header.ar_count
+    for _ in range(total_records):
+        try:
+            record, offset = parse_resource_record(data, offset)
+            records.append(record)
+        except ValueError as e:
+            print(f"  Warning: Failed to parse record: {e}", file=sys.stderr)
+            break
+
+    return header, records
+
+
+def build_mdns_query(service: str) -> bytes:
+    """Build an mDNS PTR query for a service type."""
+    # Header: ID=0 (mDNS), standard query, 1 question
+    header = struct.pack("!HHHHHH", 0, 0, 1, 0, 0, 0)
+
+    # Question: service name, PTR type, IN class
+    question = b""
+    for label in service.split("."):
+        question += bytes([len(label)]) + label.encode("utf-8")
+    question += b"\x00"  # Root label
+    question += struct.pack("!HH", DNS_TYPE_PTR, DNS_CLASS_IN)
+
+    return header + question
+
+
+def create_device_from_product_id(
+    serial: str,
+    ip: str,
+    port: int,
+    product_id: int,
+) -> Device | None:
+    """Create appropriate device class based on product ID."""
+    if not HAVE_LIFX:
+        return None
+
+    product = get_product(product_id)
+    kwargs = {"serial": serial, "ip": ip, "port": port}
+
+    # Priority-based selection matching DiscoveredDevice.create_device()
+    if is_ceiling_product(product_id):
+        return CeilingLight(**kwargs)
+    if product.has_matrix:
+        return MatrixLight(**kwargs)
+    if product.has_multizone:
+        return MultiZoneLight(**kwargs)
+    if product.has_infrared:
+        return InfraredLight(**kwargs)
+    if product.has_hev:
+        return HevLight(**kwargs)
+    if product.has_relays or (product.has_buttons and not product.has_color):
+        return None
+    return Light(**kwargs)
+
+
+async def verify_device(
+    device: Device,
+    mdns_cnt: int,
+) -> dict[str, Any]:
+    """Query device to get actual zone/tile counts and compare with mDNS cnt."""
+    result: dict[str, Any] = {
+        "device_class": type(device).__name__,
+        "mdns_cnt": mdns_cnt,
+        "actual_count": None,
+        "count_type": None,
+        "match": None,
+        "label": None,
+    }
+
+    try:
+        async with device:
+            # Get label
+            result["label"] = await device.get_label()
+
+            # Get zone/tile count based on device type
+            # Check CeilingLight first (extends MatrixLight)
+            if isinstance(device, CeilingLight):
+                result["count_type"] = "tiles"
+                chain = await device.get_device_chain()
+                result["actual_count"] = len(chain)
+            elif isinstance(device, MatrixLight):
+                result["count_type"] = "tiles"
+                chain = await device.get_device_chain()
+                result["actual_count"] = len(chain)
+            elif isinstance(device, MultiZoneLight):
+                result["count_type"] = "zones"
+                result["actual_count"] = await device.get_zone_count()
+            else:
+                result["count_type"] = "n/a (single zone)"
+                result["actual_count"] = 1
+
+            result["match"] = result["actual_count"] == mdns_cnt
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def create_mdns_socket() -> socket.socket:
+    """Create a socket suitable for mDNS queries."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+    # Try to set SO_REUSEPORT if available (Linux/macOS)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    except (AttributeError, OSError):
+        pass
+
+    # Bind to mDNS port to receive responses
+    try:
+        sock.bind(("", MDNS_PORT))
+    except OSError as e:
+        print(f"Warning: Could not bind to port {MDNS_PORT}: {e}", file=sys.stderr)
+        print(
+            "Binding to ephemeral port instead (may miss some responses)",
+            file=sys.stderr,
+        )
+        sock.bind(("", 0))
+
+    # Join multicast group (bind to all interfaces for multicast reception)
+    local_addr = socket.inet_aton("0.0.0.0")  # nosec B104
+    mreq = struct.pack("4s4s", socket.inet_aton(MDNS_ADDR), local_addr)
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+    # Set multicast TTL
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 255)
+
+    # Enable receiving our own multicast (useful for testing)
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
+
+    sock.setblocking(False)
+
+    return sock
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Probe for LIFX devices via mDNS and dump service records"
+    )
+    parser.add_argument(
+        "--timeout",
+        "-t",
+        type=float,
+        default=10.0,
+        help="Discovery timeout in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--service",
+        "-s",
+        type=str,
+        default=LIFX_SERVICE,
+        help=f"Service to query (default: {LIFX_SERVICE})",
+    )
+    parser.add_argument("--raw", action="store_true", help="Also dump raw packet hex")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Query devices to verify cnt field matches actual zone/tile count",
+    )
+    args = parser.parse_args()
+
+    if args.verify and not HAVE_LIFX:
+        print("Error: --verify requires lifx-async to be installed", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"mDNS Probe for {args.service}")
+    print(f"Timeout: {args.timeout}s")
+    if args.verify:
+        print("Verification: ENABLED")
+    print("=" * 60)
+
+    # Create socket
+    sock = create_mdns_socket()
+
+    # Build and send query
+    query = build_mdns_query(args.service)
+    print(f"\nSending PTR query for {args.service}...")
+    if args.raw:
+        print(f"Query packet ({len(query)} bytes): {query.hex()}")
+
+    sock.sendto(query, (MDNS_ADDR, MDNS_PORT))
+
+    # Collect responses
+    print("\nListening for responses...\n")
+
+    start_time = time.time()
+    seen_sources: set[str] = set()
+    response_count = 0
+
+    # Collect device info for verification
+    devices_to_verify: list[dict[str, Any]] = []
+
+    while time.time() - start_time < args.timeout:
+        remaining = args.timeout - (time.time() - start_time)
+        if remaining <= 0:
+            break
+
+        try:
+            sock.settimeout(min(remaining, 1.0))
+            data, addr = sock.recvfrom(4096)
+        except TimeoutError:
+            continue
+        except BlockingIOError:
+            time.sleep(0.1)
+            continue
+
+        source = f"{addr[0]}:{addr[1]}"
+
+        # Skip if we've seen this exact response (dedup)
+        response_key = f"{source}:{data.hex()}"
+        if response_key in seen_sources:
+            continue
+        seen_sources.add(response_key)
+
+        try:
+            header, records = parse_dns_message(data)
+
+            # Only show responses (not our own query)
+            if not header.is_response:
+                continue
+
+            # Filter for LIFX-related records
+            lifx_records = [
+                r
+                for r in records
+                if "lifx" in r.name.lower()
+                or (r.parsed_data and "lifx" in str(r.parsed_data).lower())
+            ]
+
+            if not lifx_records and args.service in [LIFX_SERVICE]:
+                # Also check if any record matches our service
+                lifx_records = [
+                    r for r in records if args.service.split(".")[0] in r.name.lower()
+                ]
+
+            if not lifx_records:
+                continue
+
+            response_count += 1
+            print(f"Response #{response_count} from {source}")
+            print(f"  {header}")
+
+            if args.raw:
+                print(f"  Raw ({len(data)} bytes): {data.hex()}")
+
+            # Extract device info from records
+            device_info: dict[str, Any] = {"ip": addr[0]}
+            for record in records:
+                if record.rtype == DNS_TYPE_SRV and record.parsed_data:
+                    device_info["port"] = record.parsed_data.port
+                elif record.rtype == DNS_TYPE_TXT and record.parsed_data:
+                    txt = record.parsed_data
+                    if hasattr(txt, "pairs"):
+                        if "id" in txt.pairs:
+                            device_info["serial"] = txt.pairs["id"]
+                        if "p" in txt.pairs:
+                            device_info["product_id"] = int(txt.pairs["p"])
+                        if "cnt" in txt.pairs:
+                            device_info["cnt"] = int(txt.pairs["cnt"])
+                        if "fw" in txt.pairs:
+                            device_info["firmware"] = txt.pairs["fw"]
+
+            # Add product name if we have registry
+            if HAVE_LIFX and "product_id" in device_info:
+                product = get_product(device_info["product_id"])
+                device_info["product_name"] = product.name
+                device_info["has_multizone"] = product.has_multizone
+                device_info["has_matrix"] = product.has_matrix
+
+            # Print records
+            print(
+                f"  Records ({len(records)} total, {len(lifx_records)} LIFX-related):"
+            )
+            for record in records:
+                prefix = "  >>> " if record in lifx_records else "      "
+                print(f"{prefix}{record}")
+
+            # Show extracted device info
+            if device_info.get("product_name"):
+                print(f"  Device: {device_info['product_name']}")
+                print(f"    Serial: {device_info.get('serial', 'N/A')}")
+                print(f"    Firmware: {device_info.get('firmware', 'N/A')}")
+                print(f"    mDNS cnt: {device_info.get('cnt', 'N/A')}")
+                if device_info.get("has_multizone"):
+                    print("    Type: MultiZone (zones expected)")
+                elif device_info.get("has_matrix"):
+                    print("    Type: Matrix (tiles expected)")
+                else:
+                    print("    Type: Single zone light")
+
+            # Store for verification
+            if args.verify and all(
+                k in device_info for k in ["serial", "ip", "port", "product_id", "cnt"]
+            ):
+                devices_to_verify.append(device_info)
+
+            print()
+
+        except Exception as e:
+            print(f"Failed to parse response from {source}: {e}", file=sys.stderr)
+            if args.raw:
+                print(f"  Raw ({len(data)} bytes): {data.hex()}", file=sys.stderr)
+            continue
+
+    sock.close()
+
+    print("=" * 60)
+    print(f"Discovery complete. Found {response_count} LIFX-related response(s).")
+
+    if response_count == 0:
+        print("\nNo LIFX devices responded. Possible reasons:")
+        print("  - No LIFX devices on the network")
+        print("  - Devices don't support mDNS (older firmware)")
+        print("  - Firewall blocking mDNS (UDP port 5353)")
+        print("  - Network doesn't allow multicast")
+        print("\nTry:")
+        print("  - Power cycling a LIFX device (triggers announcement)")
+        print("  - Running with --timeout 30 for longer wait")
+        print("  - Checking firewall settings")
+
+    # Run verification if requested
+    if args.verify and devices_to_verify:
+        print("\n" + "=" * 60)
+        print("VERIFICATION: Querying devices to compare cnt with actual counts")
+        print("=" * 60 + "\n")
+
+        async def run_verification() -> None:
+            for info in devices_to_verify:
+                device = create_device_from_product_id(
+                    serial=info["serial"],
+                    ip=info["ip"],
+                    port=info["port"],
+                    product_id=info["product_id"],
+                )
+                if device is None:
+                    print(f"  {info['serial']}: Skipped (relay/button device)")
+                    continue
+
+                result = await verify_device(device, info["cnt"])
+
+                # Format output
+                status = ""
+                if result.get("error"):
+                    status = f"ERROR: {result['error']}"
+                elif result["match"]:
+                    status = "MATCH"
+                else:
+                    status = "MISMATCH"
+
+                print(f"  {info['serial']} ({info.get('product_name', 'Unknown')}):")
+                print(f"    Label: {result.get('label', 'N/A')}")
+                print(f"    Device class: {result['device_class']}")
+                print(f"    mDNS cnt: {result['mdns_cnt']}")
+                print(f"    Actual {result['count_type']}: {result['actual_count']}")
+                print(f"    Status: {status}")
+                print()
+
+        asyncio.run(run_verification())
+
+        print("=" * 60)
+        print("Verification complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lifx/__init__.py
+++ b/src/lifx/__init__.py
@@ -10,6 +10,7 @@ from importlib.metadata import version as get_version
 from lifx.api import (
     DeviceGroup,
     discover,
+    discover_mdns,
     find_by_ip,
     find_by_label,
     find_by_serial,
@@ -48,6 +49,7 @@ from lifx.exceptions import (
     LifxUnsupportedCommandError,
 )
 from lifx.network.discovery import DiscoveredDevice, discover_devices
+from lifx.network.mdns import LifxServiceRecord, discover_lifx_services
 from lifx.products import ProductCapability, ProductInfo, ProductRegistry
 from lifx.protocol.protocol_types import (
     Direction,
@@ -100,12 +102,16 @@ __all__ = [
     # High-level API
     "DeviceGroup",
     "discover",
+    "discover_mdns",
     "find_by_serial",
     "find_by_label",
     "find_by_ip",
     # Discovery (low-level)
     "discover_devices",
     "DiscoveredDevice",
+    # mDNS Discovery (low-level)
+    "discover_lifx_services",
+    "LifxServiceRecord",
     # Products
     "ProductInfo",
     "ProductRegistry",

--- a/src/lifx/const.py
+++ b/src/lifx/const.py
@@ -39,6 +39,19 @@ STATE_REFRESH_DEBOUNCE_MS: Final[int] = 300
 DEFAULT_MAX_RETRIES: Final[int] = 8
 
 # ============================================================================
+# mDNS Constants
+# ============================================================================
+
+# mDNS multicast address (IPv4)
+MDNS_ADDRESS: Final[str] = "224.0.0.251"
+
+# mDNS port
+MDNS_PORT: Final[int] = 5353
+
+# LIFX mDNS service type
+LIFX_MDNS_SERVICE: Final[str] = "_lifx._udp.local"
+
+# ============================================================================
 # HSBK Min/Max Values
 # ============================================================================
 

--- a/src/lifx/network/mdns/__init__.py
+++ b/src/lifx/network/mdns/__init__.py
@@ -1,0 +1,58 @@
+"""mDNS/DNS-SD discovery for LIFX devices.
+
+This module provides mDNS-based discovery using the _lifx._udp.local service type.
+It uses only Python stdlib (no external dependencies).
+
+Example:
+    Low-level API (raw mDNS records):
+    ```python
+    async for record in discover_lifx_services():
+        print(f"Found: {record.serial} at {record.ip}:{record.port}")
+    ```
+
+    High-level API (device instances):
+    ```python
+    async for device in discover_devices_mdns():
+        print(f"Found {type(device).__name__}: {device.serial}")
+    ```
+"""
+
+from lifx.network.mdns.discovery import (
+    create_device_from_record,
+    discover_devices_mdns,
+    discover_lifx_services,
+)
+from lifx.network.mdns.dns import (
+    DnsHeader,
+    DnsResourceRecord,
+    ParsedDnsResponse,
+    SrvData,
+    TxtData,
+    build_ptr_query,
+    parse_dns_response,
+    parse_name,
+    parse_txt_record,
+)
+from lifx.network.mdns.transport import MdnsTransport
+from lifx.network.mdns.types import LifxServiceRecord
+
+__all__ = [
+    # Types
+    "LifxServiceRecord",
+    # Discovery functions
+    "discover_lifx_services",
+    "discover_devices_mdns",
+    "create_device_from_record",
+    # DNS parsing
+    "DnsHeader",
+    "DnsResourceRecord",
+    "ParsedDnsResponse",
+    "SrvData",
+    "TxtData",
+    "build_ptr_query",
+    "parse_dns_response",
+    "parse_name",
+    "parse_txt_record",
+    # Transport
+    "MdnsTransport",
+]

--- a/src/lifx/network/mdns/discovery.py
+++ b/src/lifx/network/mdns/discovery.py
@@ -1,0 +1,403 @@
+"""mDNS discovery for LIFX devices.
+
+This module provides discovery functions using mDNS/DNS-SD to find
+LIFX devices on the local network.
+
+Example:
+    Low-level API (raw service records):
+    ```python
+    async for record in discover_lifx_services():
+        print(f"Found: {record.serial} at {record.ip}:{record.port}")
+    ```
+
+    High-level API (device instances):
+    ```python
+    async for device in discover_devices_mdns():
+        async with device:
+            print(f"Found: {await device.get_label()}")
+    ```
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+from lifx.const import (
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_REQUEST_TIMEOUT,
+    DISCOVERY_TIMEOUT,
+    IDLE_TIMEOUT_MULTIPLIER,
+    LIFX_MDNS_SERVICE,
+    MAX_RESPONSE_TIME,
+)
+from lifx.network.mdns.dns import (
+    DNS_TYPE_A,
+    DNS_TYPE_PTR,
+    DNS_TYPE_SRV,
+    DNS_TYPE_TXT,
+    SrvData,
+    TxtData,
+    build_ptr_query,
+    parse_dns_response,
+)
+from lifx.network.mdns.transport import MdnsTransport
+from lifx.network.mdns.types import LifxServiceRecord
+
+if TYPE_CHECKING:
+    from lifx.devices.light import Light
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _extract_lifx_info(
+    records: list,
+    source_ip: str,
+) -> LifxServiceRecord | None:
+    """Extract LIFX device info from mDNS records.
+
+    Args:
+        records: List of DnsResourceRecord from the response
+        source_ip: IP address the response came from
+
+    Returns:
+        LifxServiceRecord if valid LIFX device info found, None otherwise
+    """
+    # Find records of each type
+    srv_data: SrvData | None = None
+    txt_data: TxtData | None = None
+    a_record_ip: str | None = None
+
+    for record in records:
+        if record.rtype == DNS_TYPE_SRV and isinstance(record.parsed_data, SrvData):
+            srv_data = record.parsed_data
+        elif record.rtype == DNS_TYPE_TXT and isinstance(record.parsed_data, TxtData):
+            txt_data = record.parsed_data
+        elif record.rtype == DNS_TYPE_A and isinstance(record.parsed_data, str):
+            a_record_ip = record.parsed_data
+
+    # Need at least TXT record to identify the device
+    if txt_data is None:
+        return None
+
+    # Extract required fields from TXT record
+    serial = txt_data.pairs.get("id", "").lower()
+    product_id_str = txt_data.pairs.get("p", "")
+    firmware = txt_data.pairs.get("fw", "")
+
+    # Validate required fields
+    if not serial or not product_id_str:
+        return None
+
+    try:
+        product_id = int(product_id_str)
+    except ValueError:
+        return None
+
+    # Get port from SRV record or use default
+    port = srv_data.port if srv_data else 56700
+
+    # Get IP from A record or use source IP
+    ip = a_record_ip if a_record_ip else source_ip
+
+    return LifxServiceRecord(
+        serial=serial,
+        ip=ip,
+        port=port,
+        product_id=product_id,
+        firmware=firmware,
+    )
+
+
+def create_device_from_record(
+    record: LifxServiceRecord,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> Light | None:
+    """Create appropriate device class based on product ID from mDNS record.
+
+    Uses the product registry to determine device capabilities and instantiate
+    the correct device class (Light, MatrixLight, MultiZoneLight, etc.).
+
+    Args:
+        record: LifxServiceRecord from mDNS discovery
+        timeout: Request timeout for the device
+        max_retries: Maximum retry attempts for requests
+
+    Returns:
+        Device instance of the appropriate type, or None if device should be skipped
+        (e.g., relay/button-only devices)
+
+    Example:
+        ```python
+        async for record in discover_lifx_services():
+            device = create_device_from_record(record)
+            if device:
+                async with device:
+                    print(f"Device: {await device.get_label()}")
+        ```
+    """
+    from lifx.devices.ceiling import CeilingLight
+    from lifx.devices.hev import HevLight
+    from lifx.devices.infrared import InfraredLight
+    from lifx.devices.light import Light
+    from lifx.devices.matrix import MatrixLight
+    from lifx.devices.multizone import MultiZoneLight
+    from lifx.products import get_product, is_ceiling_product
+
+    product = get_product(record.product_id)
+    kwargs = {
+        "serial": record.serial,
+        "ip": record.ip,
+        "port": record.port,
+        "timeout": timeout,
+        "max_retries": max_retries,
+    }
+
+    # Priority-based selection matching DiscoveredDevice.create_device()
+    if is_ceiling_product(record.product_id):
+        return CeilingLight(**kwargs)
+    if product.has_matrix:
+        return MatrixLight(**kwargs)
+    if product.has_multizone:
+        return MultiZoneLight(**kwargs)
+    if product.has_infrared:
+        return InfraredLight(**kwargs)
+    if product.has_hev:
+        return HevLight(**kwargs)
+    if product.has_relays or (product.has_buttons and not product.has_color):
+        return None
+    return Light(**kwargs)
+
+
+async def discover_lifx_services(
+    timeout: float = DISCOVERY_TIMEOUT,
+    max_response_time: float = MAX_RESPONSE_TIME,
+    idle_timeout_multiplier: float = IDLE_TIMEOUT_MULTIPLIER,
+) -> AsyncGenerator[LifxServiceRecord, None]:
+    """Discover LIFX devices via mDNS and yield service records.
+
+    Sends an mDNS PTR query for _lifx._udp.local and yields service records
+    as devices respond. Records are deduplicated by serial number.
+
+    This is the low-level API that provides raw mDNS data. For device instances,
+    use discover_devices_mdns() instead.
+
+    Args:
+        timeout: Overall discovery timeout in seconds
+        max_response_time: Maximum expected response time
+        idle_timeout_multiplier: Multiplier for idle timeout
+
+    Yields:
+        LifxServiceRecord for each discovered device
+
+    Example:
+        ```python
+        async for record in discover_lifx_services(timeout=10.0):
+            print(f"Found: {record.serial} (product {record.product_id})")
+            print(f"  IP: {record.ip}:{record.port}")
+            print(f"  Firmware: {record.firmware}")
+        ```
+    """
+    seen_serials: set[str] = set()
+    start_time = time.time()
+
+    async with MdnsTransport() as transport:
+        # Build and send PTR query
+        query = build_ptr_query(LIFX_MDNS_SERVICE)
+        request_time = time.time()
+
+        _LOGGER.debug(
+            {
+                "class": "discover_lifx_services",
+                "method": "discover",
+                "action": "sending_query",
+                "service": LIFX_MDNS_SERVICE,
+                "timeout": timeout,
+            }
+        )
+
+        await transport.send(query)
+
+        # Calculate idle timeout
+        idle_timeout = max_response_time * idle_timeout_multiplier
+        last_response_time = request_time
+
+        # Collect responses with dynamic timeout
+        while True:
+            # Calculate elapsed time since last response
+            elapsed_since_last = time.time() - last_response_time
+
+            # Stop if we've been idle too long
+            if elapsed_since_last >= idle_timeout:
+                _LOGGER.debug(
+                    {
+                        "class": "discover_lifx_services",
+                        "method": "discover",
+                        "action": "idle_timeout",
+                        "idle_time": elapsed_since_last,
+                        "idle_timeout": idle_timeout,
+                    }
+                )
+                break
+
+            # Stop if we've exceeded the overall timeout
+            if time.time() - request_time >= timeout:
+                _LOGGER.debug(
+                    {
+                        "class": "discover_lifx_services",
+                        "method": "discover",
+                        "action": "overall_timeout",
+                        "elapsed": time.time() - request_time,
+                        "timeout": timeout,
+                    }
+                )
+                break
+
+            # Calculate remaining timeout
+            remaining_idle = idle_timeout - elapsed_since_last
+            remaining_overall = timeout - (time.time() - request_time)
+            remaining = min(remaining_idle, remaining_overall)
+
+            try:
+                data, addr = await transport.receive(timeout=remaining)
+                response_timestamp = time.time()
+
+            except Exception:
+                # Timeout or error - stop collecting
+                _LOGGER.debug(
+                    {
+                        "class": "discover_lifx_services",
+                        "method": "discover",
+                        "action": "no_responses",
+                    }
+                )
+                break
+
+            try:
+                # Parse DNS response
+                response = parse_dns_response(data)
+
+                # Only process responses (not queries)
+                if not response.header.is_response:
+                    continue
+
+                # Check if this is a LIFX response (has PTR for _lifx._udp.local)
+                has_lifx_ptr = any(
+                    r.rtype == DNS_TYPE_PTR and LIFX_MDNS_SERVICE in r.name
+                    for r in response.records
+                )
+
+                if not has_lifx_ptr:
+                    # Might still be a LIFX device responding without PTR
+                    # Check TXT records for LIFX format
+                    has_lifx_txt = any(
+                        r.rtype == DNS_TYPE_TXT
+                        and isinstance(r.parsed_data, TxtData)
+                        and "id" in r.parsed_data.pairs
+                        and "p" in r.parsed_data.pairs
+                        for r in response.records
+                    )
+                    if not has_lifx_txt:
+                        continue
+
+                # Extract device info from records
+                record = _extract_lifx_info(response.records, addr[0])
+
+                if record is None:
+                    continue
+
+                # Deduplicate by serial
+                if record.serial in seen_serials:
+                    continue
+
+                seen_serials.add(record.serial)
+
+                _LOGGER.debug(
+                    {
+                        "class": "discover_lifx_services",
+                        "method": "discover",
+                        "action": "device_found",
+                        "serial": record.serial,
+                        "ip": record.ip,
+                        "port": record.port,
+                        "product_id": record.product_id,
+                    }
+                )
+
+                yield record
+
+                # Update last response time for idle timeout
+                last_response_time = response_timestamp
+
+            except Exception as e:
+                _LOGGER.debug(
+                    {
+                        "class": "discover_lifx_services",
+                        "method": "discover",
+                        "action": "parse_error",
+                        "error": str(e),
+                        "source_ip": addr[0],
+                    }
+                )
+                continue
+
+        _LOGGER.debug(
+            {
+                "class": "discover_lifx_services",
+                "method": "discover",
+                "action": "complete",
+                "devices_found": len(seen_serials),
+                "elapsed": time.time() - start_time,
+            }
+        )
+
+
+async def discover_devices_mdns(
+    timeout: float = DISCOVERY_TIMEOUT,
+    max_response_time: float = MAX_RESPONSE_TIME,
+    idle_timeout_multiplier: float = IDLE_TIMEOUT_MULTIPLIER,
+    device_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> AsyncGenerator[Light, None]:
+    """Discover LIFX devices via mDNS and yield device instances.
+
+    This is the high-level API that yields fully-typed device instances
+    (Light, MatrixLight, MultiZoneLight, etc.) based on product capabilities.
+
+    Devices that are not lights (relays, buttons without color) are automatically
+    filtered out and not yielded.
+
+    Args:
+        timeout: Overall discovery timeout in seconds
+        max_response_time: Maximum expected response time
+        idle_timeout_multiplier: Multiplier for idle timeout
+        device_timeout: Request timeout for created devices
+        max_retries: Maximum retry attempts for device requests
+
+    Yields:
+        Device instances (Light, MatrixLight, etc.) as they are discovered
+
+    Example:
+        ```python
+        async for device in discover_devices_mdns(timeout=10.0):
+            async with device:
+                label = await device.get_label()
+                print(f"{type(device).__name__}: {label} at {device.ip}")
+        ```
+    """
+    async for record in discover_lifx_services(
+        timeout=timeout,
+        max_response_time=max_response_time,
+        idle_timeout_multiplier=idle_timeout_multiplier,
+    ):
+        device = create_device_from_record(
+            record,
+            timeout=device_timeout,
+            max_retries=max_retries,
+        )
+
+        if device is not None:
+            yield device

--- a/src/lifx/network/mdns/dns.py
+++ b/src/lifx/network/mdns/dns.py
@@ -1,0 +1,356 @@
+"""DNS wire format parser for mDNS discovery.
+
+This module provides minimal DNS parsing for mDNS service discovery,
+supporting PTR, SRV, A, and TXT record types.
+
+Uses only Python stdlib (struct, socket).
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+from dataclasses import dataclass, field
+from typing import Any
+
+# DNS record types
+DNS_TYPE_A = 1
+DNS_TYPE_PTR = 12
+DNS_TYPE_TXT = 16
+DNS_TYPE_AAAA = 28
+DNS_TYPE_SRV = 33
+
+# DNS classes
+DNS_CLASS_IN = 1
+DNS_CLASS_UNIQUE = 0x8001  # Cache flush bit set
+
+# Type names for display
+_TYPE_NAMES = {
+    DNS_TYPE_A: "A",
+    DNS_TYPE_PTR: "PTR",
+    DNS_TYPE_TXT: "TXT",
+    DNS_TYPE_AAAA: "AAAA",
+    DNS_TYPE_SRV: "SRV",
+}
+
+
+@dataclass
+class DnsHeader:
+    """DNS message header (12 bytes).
+
+    Attributes:
+        id: Transaction ID (0 for mDNS)
+        flags: DNS flags
+        qd_count: Question count
+        an_count: Answer count
+        ns_count: Authority count
+        ar_count: Additional count
+    """
+
+    id: int
+    flags: int
+    qd_count: int
+    an_count: int
+    ns_count: int
+    ar_count: int
+
+    @property
+    def is_response(self) -> bool:
+        """Check if this is a response (QR bit set)."""
+        return bool(self.flags & 0x8000)
+
+    @classmethod
+    def parse(cls, data: bytes) -> DnsHeader:
+        """Parse a DNS header from bytes.
+
+        Args:
+            data: At least 12 bytes of DNS header data
+
+        Returns:
+            Parsed DnsHeader
+
+        Raises:
+            ValueError: If data is too short
+        """
+        if len(data) < 12:
+            raise ValueError(f"DNS header too short: {len(data)} bytes")
+        id_, flags, qd, an, ns, ar = struct.unpack("!HHHHHH", data[:12])
+        return cls(id_, flags, qd, an, ns, ar)
+
+
+@dataclass
+class SrvData:
+    """Parsed SRV record data.
+
+    Attributes:
+        priority: Service priority
+        weight: Service weight
+        port: Service port
+        target: Target hostname
+    """
+
+    priority: int
+    weight: int
+    port: int
+    target: str
+
+
+@dataclass
+class TxtData:
+    """Parsed TXT record data.
+
+    Attributes:
+        strings: Raw TXT strings
+        pairs: Key-value pairs parsed from strings containing '='
+    """
+
+    strings: list[str] = field(default_factory=list)
+    pairs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DnsResourceRecord:
+    """DNS resource record.
+
+    Attributes:
+        name: Record name
+        rtype: Record type (A, PTR, TXT, SRV, etc.)
+        rclass: Record class (usually IN)
+        ttl: Time to live in seconds
+        rdata: Raw record data bytes
+        parsed_data: Parsed record data (type varies by rtype)
+    """
+
+    name: str
+    rtype: int
+    rclass: int
+    ttl: int
+    rdata: bytes
+    parsed_data: Any = None
+
+    @property
+    def type_name(self) -> str:
+        """Get human-readable record type name."""
+        return _TYPE_NAMES.get(self.rtype, f"TYPE{self.rtype}")
+
+    @property
+    def cache_flush(self) -> bool:
+        """Check if cache flush bit is set (mDNS unique)."""
+        return bool(self.rclass & 0x8000)
+
+
+@dataclass
+class ParsedDnsResponse:
+    """Parsed DNS response message.
+
+    Attributes:
+        header: DNS header
+        records: All resource records (answers + authority + additional)
+    """
+
+    header: DnsHeader
+    records: list[DnsResourceRecord]
+
+
+def parse_name(data: bytes, offset: int) -> tuple[str, int]:
+    """Parse a DNS name with compression pointer support.
+
+    DNS names use length-prefixed labels, with 0xC0 prefix indicating
+    compression pointers to earlier positions in the message.
+
+    Args:
+        data: Complete DNS message bytes
+        offset: Starting offset in data
+
+    Returns:
+        Tuple of (parsed name, new offset after the name)
+
+    Raises:
+        ValueError: If name parsing fails
+    """
+    labels: list[str] = []
+    original_offset = offset
+    jumped = False
+    max_jumps = 10  # Prevent infinite loops
+    jumps = 0
+
+    while True:
+        if offset >= len(data):
+            raise ValueError(f"DNS name parsing ran off end of data at offset {offset}")
+
+        length = data[offset]
+
+        # Check for compression pointer (top 2 bits set)
+        if (length & 0xC0) == 0xC0:
+            if offset + 1 >= len(data):
+                raise ValueError("Compression pointer incomplete")
+            # Pointer to earlier in message
+            pointer = ((length & 0x3F) << 8) | data[offset + 1]
+            if not jumped:
+                original_offset = offset + 2
+            jumped = True
+            offset = pointer
+            jumps += 1
+            if jumps > max_jumps:
+                raise ValueError("Too many compression pointer jumps")
+            continue
+
+        offset += 1
+
+        if length == 0:
+            # End of name
+            break
+
+        if offset + length > len(data):
+            raise ValueError(
+                f"Label extends beyond data: offset={offset}, length={length}"
+            )
+
+        label = data[offset : offset + length].decode("utf-8", errors="replace")
+        labels.append(label)
+        offset += length
+
+    name = ".".join(labels) if labels else "."
+    final_offset = original_offset if jumped else offset
+
+    return name, final_offset
+
+
+def parse_txt_record(rdata: bytes) -> TxtData:
+    """Parse TXT record data.
+
+    TXT records contain one or more length-prefixed strings.
+    LIFX uses key=value format in these strings.
+
+    Args:
+        rdata: TXT record data bytes
+
+    Returns:
+        Parsed TxtData with strings and key-value pairs
+    """
+    txt_data = TxtData()
+    offset = 0
+
+    while offset < len(rdata):
+        str_len = rdata[offset]
+        offset += 1
+        if offset + str_len > len(rdata):
+            break
+        txt_str = rdata[offset : offset + str_len].decode("utf-8", errors="replace")
+        txt_data.strings.append(txt_str)
+        # Try to parse as key=value
+        if "=" in txt_str:
+            key, _, value = txt_str.partition("=")
+            txt_data.pairs[key] = value
+        offset += str_len
+
+    return txt_data
+
+
+def _parse_resource_record(data: bytes, offset: int) -> tuple[DnsResourceRecord, int]:
+    """Parse a single DNS resource record.
+
+    Args:
+        data: Complete DNS message bytes
+        offset: Starting offset of the record
+
+    Returns:
+        Tuple of (parsed record, new offset after the record)
+
+    Raises:
+        ValueError: If record parsing fails
+    """
+    name, offset = parse_name(data, offset)
+
+    if offset + 10 > len(data):
+        raise ValueError(f"Resource record header incomplete at offset {offset}")
+
+    rtype, rclass, ttl, rdlength = struct.unpack("!HHIH", data[offset : offset + 10])
+    offset += 10
+
+    if offset + rdlength > len(data):
+        available = len(data) - offset
+        raise ValueError(
+            f"Resource record data incomplete: need {rdlength}, have {available}"
+        )
+
+    rdata = data[offset : offset + rdlength]
+    offset += rdlength
+
+    # Parse specific record types
+    parsed_data: Any = None
+
+    if rtype == DNS_TYPE_A and rdlength == 4:
+        parsed_data = socket.inet_ntoa(rdata)
+
+    elif rtype == DNS_TYPE_AAAA and rdlength == 16:
+        parsed_data = socket.inet_ntop(socket.AF_INET6, rdata)
+
+    elif rtype == DNS_TYPE_PTR:
+        parsed_data, _ = parse_name(data, offset - rdlength)
+
+    elif rtype == DNS_TYPE_SRV and rdlength >= 6:
+        priority, weight, port = struct.unpack("!HHH", rdata[:6])
+        target, _ = parse_name(data, offset - rdlength + 6)
+        parsed_data = SrvData(priority, weight, port, target)
+
+    elif rtype == DNS_TYPE_TXT:
+        parsed_data = parse_txt_record(rdata)
+
+    return DnsResourceRecord(name, rtype, rclass, ttl, rdata, parsed_data), offset
+
+
+def parse_dns_response(data: bytes) -> ParsedDnsResponse:
+    """Parse a complete DNS response message.
+
+    Args:
+        data: Complete DNS message bytes
+
+    Returns:
+        ParsedDnsResponse containing header and all records
+
+    Raises:
+        ValueError: If message parsing fails
+    """
+    header = DnsHeader.parse(data)
+    offset = 12
+    records: list[DnsResourceRecord] = []
+
+    # Skip questions (we don't need them for responses)
+    for _ in range(header.qd_count):
+        _, offset = parse_name(data, offset)
+        offset += 4  # QTYPE + QCLASS
+
+    # Parse all resource records (answers, authority, additional)
+    total_records = header.an_count + header.ns_count + header.ar_count
+    for _ in range(total_records):
+        record, offset = _parse_resource_record(data, offset)
+        records.append(record)
+
+    return ParsedDnsResponse(header, records)
+
+
+def build_ptr_query(service: str) -> bytes:
+    """Build an mDNS PTR query for a service type.
+
+    Args:
+        service: Service name (e.g., "_lifx._udp.local")
+
+    Returns:
+        DNS query packet bytes ready to send
+
+    Example:
+        >>> query = build_ptr_query("_lifx._udp.local")
+        >>> # Send to 224.0.0.251:5353
+    """
+    # Header: ID=0 (mDNS), standard query, 1 question
+    header = struct.pack("!HHHHHH", 0, 0, 1, 0, 0, 0)
+
+    # Question: service name, PTR type, IN class
+    question = b""
+    for label in service.split("."):
+        question += bytes([len(label)]) + label.encode("utf-8")
+    question += b"\x00"  # Root label
+    question += struct.pack("!HH", DNS_TYPE_PTR, DNS_CLASS_IN)
+
+    return header + question

--- a/src/lifx/network/mdns/transport.py
+++ b/src/lifx/network/mdns/transport.py
@@ -1,0 +1,313 @@
+"""mDNS transport for multicast UDP communication.
+
+This module provides a UDP transport specifically for mDNS queries,
+with multicast group joining and appropriate socket configuration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import struct
+from asyncio import DatagramTransport
+from typing import TYPE_CHECKING
+
+from lifx.const import MDNS_ADDRESS, MDNS_PORT
+from lifx.exceptions import LifxNetworkError, LifxTimeoutError
+
+if TYPE_CHECKING:
+    pass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _MdnsProtocol(asyncio.DatagramProtocol):
+    """Asyncio protocol for mDNS UDP communication."""
+
+    def __init__(self) -> None:
+        """Initialize the protocol."""
+        self.queue: asyncio.Queue[tuple[bytes, tuple[str, int]]] = asyncio.Queue()
+        self._transport: DatagramTransport | None = None
+
+    def connection_made(self, transport: DatagramTransport) -> None:  # type: ignore[override]
+        """Called when connection is established."""
+        self._transport = transport
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        """Called when a datagram is received."""
+        self.queue.put_nowait((data, addr))
+
+    def error_received(self, exc: Exception) -> None:
+        """Called when an error is received."""
+        _LOGGER.debug(
+            {
+                "class": "_MdnsProtocol",
+                "method": "error_received",
+                "action": "error",
+                "error": str(exc),
+            }
+        )
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        """Called when connection is lost."""
+        _LOGGER.debug(
+            {
+                "class": "_MdnsProtocol",
+                "method": "connection_lost",
+                "action": "lost",
+                "error": str(exc) if exc else None,
+            }
+        )
+
+
+class MdnsTransport:
+    """UDP transport for mDNS multicast communication.
+
+    This transport is specifically designed for mDNS queries and responses,
+    with support for multicast group membership and appropriate socket options.
+
+    Example:
+        >>> async with MdnsTransport() as transport:
+        ...     await transport.send(query, (MDNS_ADDRESS, MDNS_PORT))
+        ...     data, addr = await transport.receive(timeout=5.0)
+    """
+
+    def __init__(self) -> None:
+        """Initialize mDNS transport."""
+        self._protocol: _MdnsProtocol | None = None
+        self._transport: DatagramTransport | None = None
+        self._socket: socket.socket | None = None
+
+    async def __aenter__(self) -> MdnsTransport:
+        """Enter async context manager."""
+        await self.open()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit async context manager."""
+        await self.close()
+
+    async def open(self) -> None:
+        """Open the mDNS socket with multicast configuration.
+
+        Creates a UDP socket, configures it for mDNS multicast,
+        and joins the mDNS multicast group.
+
+        Raises:
+            LifxNetworkError: If socket creation or configuration fails
+        """
+        if self._protocol is not None:
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "open",
+                    "action": "already_open",
+                }
+            )
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+
+            # Create and configure socket manually for multicast
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+            # Try to set SO_REUSEPORT if available (Linux/macOS)
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            except (AttributeError, OSError):
+                pass
+
+            # Bind to mDNS port (or ephemeral if busy)
+            try:
+                sock.bind(("", MDNS_PORT))
+                _LOGGER.debug(
+                    {
+                        "class": "MdnsTransport",
+                        "method": "open",
+                        "action": "bound_to_mdns_port",
+                        "port": MDNS_PORT,
+                    }
+                )
+            except OSError as e:
+                _LOGGER.debug(
+                    {
+                        "class": "MdnsTransport",
+                        "method": "open",
+                        "action": "mdns_port_busy",
+                        "error": str(e),
+                    }
+                )
+                # Fall back to ephemeral port
+                sock.bind(("", 0))
+                _LOGGER.debug(
+                    {
+                        "class": "MdnsTransport",
+                        "method": "open",
+                        "action": "bound_to_ephemeral_port",
+                        "port": sock.getsockname()[1],
+                    }
+                )
+
+            # Join mDNS multicast group
+            mreq = struct.pack("4sl", socket.inet_aton(MDNS_ADDRESS), socket.INADDR_ANY)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "open",
+                    "action": "joined_multicast_group",
+                    "group": MDNS_ADDRESS,
+                }
+            )
+
+            # Set multicast TTL (1 for link-local)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
+
+            # Make socket non-blocking
+            sock.setblocking(False)
+            self._socket = sock
+
+            # Create protocol
+            protocol = _MdnsProtocol()
+            self._protocol = protocol
+
+            # Create datagram endpoint using our configured socket
+            self._transport, _ = await loop.create_datagram_endpoint(
+                lambda: protocol,
+                sock=sock,
+            )
+
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "open",
+                    "action": "opened",
+                }
+            )
+
+        except OSError as e:
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "open",
+                    "action": "failed",
+                    "error": str(e),
+                }
+            )
+            raise LifxNetworkError(f"Failed to open mDNS socket: {e}") from e
+
+    async def send(self, data: bytes, address: tuple[str, int] | None = None) -> None:
+        """Send data to mDNS multicast address.
+
+        Args:
+            data: Bytes to send
+            address: Target address (defaults to mDNS multicast address)
+
+        Raises:
+            LifxNetworkError: If socket is not open or send fails
+        """
+        if self._transport is None or self._protocol is None:
+            raise LifxNetworkError("Socket not open")
+
+        if address is None:
+            address = (MDNS_ADDRESS, MDNS_PORT)
+
+        try:
+            self._transport.sendto(data, address)
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "send",
+                    "action": "sent",
+                    "size": len(data),
+                    "destination": address,
+                }
+            )
+        except OSError as e:
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "send",
+                    "action": "failed",
+                    "destination": address,
+                    "error": str(e),
+                }
+            )
+            raise LifxNetworkError(f"Failed to send mDNS data: {e}") from e
+
+    async def receive(self, timeout: float = 5.0) -> tuple[bytes, tuple[str, int]]:
+        """Receive data from socket.
+
+        Args:
+            timeout: Timeout in seconds
+
+        Returns:
+            Tuple of (data, address) where address is (host, port)
+
+        Raises:
+            LifxTimeoutError: If no data received within timeout
+            LifxNetworkError: If socket is not open or receive fails
+        """
+        if self._protocol is None:
+            raise LifxNetworkError("Socket not open")
+
+        try:
+            async with asyncio.timeout(timeout):
+                data, addr = await self._protocol.queue.get()
+                return data, addr
+        except TimeoutError as e:
+            raise LifxTimeoutError(f"No mDNS data received within {timeout}s") from e
+        except OSError as e:
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "receive",
+                    "action": "failed",
+                    "error": str(e),
+                }
+            )
+            raise LifxNetworkError(f"Failed to receive mDNS data: {e}") from e
+
+    async def close(self) -> None:
+        """Close the mDNS socket."""
+        if self._transport is not None:
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "close",
+                    "action": "closing",
+                }
+            )
+
+            # Leave multicast group
+            if self._socket is not None:
+                try:
+                    mreq = struct.pack(
+                        "4sl", socket.inet_aton(MDNS_ADDRESS), socket.INADDR_ANY
+                    )
+                    self._socket.setsockopt(
+                        socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, mreq
+                    )
+                except OSError:
+                    pass  # Ignore errors when leaving group
+
+            self._transport.close()
+            self._transport = None
+            self._protocol = None
+            self._socket = None
+
+            _LOGGER.debug(
+                {
+                    "class": "MdnsTransport",
+                    "method": "close",
+                    "action": "closed",
+                }
+            )
+
+    @property
+    def is_open(self) -> bool:
+        """Check if socket is open."""
+        return self._protocol is not None

--- a/src/lifx/network/mdns/types.py
+++ b/src/lifx/network/mdns/types.py
@@ -1,0 +1,35 @@
+"""Type definitions for mDNS discovery.
+
+This module defines the data structures used for mDNS service discovery.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LifxServiceRecord:
+    """Information about a LIFX device discovered via mDNS.
+
+    Attributes:
+        serial: Device serial number as 12-digit hex string (e.g., "d073d5123456")
+        ip: Device IP address
+        port: Device UDP port (typically 56700)
+        product_id: Product ID from TXT record 'p' field
+        firmware: Firmware version from TXT record 'fw' field
+    """
+
+    serial: str
+    ip: str
+    port: int
+    product_id: int
+    firmware: str
+
+    def __hash__(self) -> int:
+        """Hash based on serial number for deduplication."""
+        return hash(self.serial)
+
+    def __eq__(self, other: object) -> bool:
+        """Equality based on serial number."""
+        if not isinstance(other, LifxServiceRecord):
+            return False
+        return self.serial == other.serial

--- a/tests/test_network/test_mdns/__init__.py
+++ b/tests/test_network/test_mdns/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for mDNS discovery module."""

--- a/tests/test_network/test_mdns/conftest.py
+++ b/tests/test_network/test_mdns/conftest.py
@@ -1,0 +1,152 @@
+"""Test fixtures for mDNS tests."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+
+@pytest.fixture
+def sample_ptr_query() -> bytes:
+    """Sample PTR query for _lifx._udp.local."""
+    # Build a PTR query for _lifx._udp.local
+    # Header: ID=0, standard query (flags=0), 1 question
+    header = struct.pack("!HHHHHH", 0, 0, 1, 0, 0, 0)
+
+    # Question: _lifx._udp.local PTR IN
+    question = (
+        b"\x05_lifx"  # 5 bytes: "_lifx"
+        b"\x04_udp"  # 4 bytes: "_udp"
+        b"\x05local"  # 5 bytes: "local"
+        b"\x00"  # Root label
+        b"\x00\x0c"  # Type PTR (12)
+        b"\x00\x01"  # Class IN (1)
+    )
+    return header + question
+
+
+@pytest.fixture
+def sample_txt_data() -> bytes:
+    """Sample TXT record data in LIFX format."""
+    # TXT data format: length-prefixed strings
+    txt_strings = [
+        "tm=1",
+        "cm=0",
+        "cnt=5",
+        "ts=1753699325000000000",
+        "fw=4.112",
+        "p=222",
+        "v=1",
+        "id=d073d5882c19",
+    ]
+
+    data = b""
+    for s in txt_strings:
+        encoded = s.encode("utf-8")
+        data += bytes([len(encoded)]) + encoded
+    return data
+
+
+@pytest.fixture
+def sample_a_record_data() -> bytes:
+    """Sample A record data for 192.168.19.185."""
+    return bytes([192, 168, 19, 185])
+
+
+@pytest.fixture
+def sample_srv_data() -> bytes:
+    """Sample SRV record data: priority=0, weight=0, port=56700, target=host.local."""
+    # Priority, weight, port
+    header = struct.pack("!HHH", 0, 0, 56700)
+    # Target: host.local (compressed or not - for simplicity, uncompressed)
+    target = b"\x04host\x05local\x00"
+    return header + target
+
+
+@pytest.fixture
+def simple_dns_response() -> bytes:
+    """A simple DNS response with one A record.
+
+    This is a minimal valid mDNS response.
+    """
+    # Header: ID=0, response (0x8400), 0 questions, 1 answer
+    header = struct.pack("!HHHHHH", 0, 0x8400, 0, 1, 0, 0)
+
+    # Answer: test.local A 192.168.1.1
+    name = b"\x04test\x05local\x00"  # "test.local"
+    rr_header = struct.pack(
+        "!HHIH",
+        1,  # Type A
+        1,  # Class IN
+        120,  # TTL
+        4,  # RDLength
+    )
+    rdata = bytes([192, 168, 1, 1])
+
+    return header + name + rr_header + rdata
+
+
+@pytest.fixture
+def lifx_dns_response() -> bytes:
+    """A realistic LIFX mDNS response with PTR, SRV, TXT, and A records.
+
+    Simulates what a LIFX device would send in response to a PTR query.
+    """
+    # Header: ID=0, response (0x8400), 0 questions, 3 answers, 0 authority, 1 additional
+    header = struct.pack("!HHHHHH", 0, 0x8400, 0, 3, 0, 1)
+
+    # Build the message body
+    body = b""
+
+    # Answer 1: PTR record - _lifx._udp.local -> D073D5882C19._lifx._udp.local
+    # Name: _lifx._udp.local (offset will be 12)
+    body += b"\x05_lifx\x04_udp\x05local\x00"  # offset 12, ends at ~27
+    ptr_name_offset = 12
+    body += struct.pack("!HHIH", 12, 1, 4500, 0)  # PTR, IN, TTL, placeholder rdlength
+
+    # PTR target: D073D5882C19._lifx._udp.local
+    ptr_target = b"\x0cD073D5882C19"  # 12 chars
+    # Use compression pointer to _lifx._udp.local
+    ptr_target += struct.pack("!H", 0xC000 | ptr_name_offset)
+    # Update rdlength
+    body = body[:-2] + struct.pack("!H", len(ptr_target)) + ptr_target
+
+    # Answer 2: SRV record - D073D5882C19._lifx._udp.local -> D073D5882C19.local
+    # Build without compression for simplicity in test
+    srv_name = b"\x0cD073D5882C19\x05_lifx\x04_udp\x05local\x00"
+    body += srv_name
+    body += struct.pack(
+        "!HHIH", 33, 0x8001, 120, 0
+    )  # SRV, cache-flush, TTL, placeholder
+    srv_target = b"\x0cD073D5882C19\x05local\x00"
+    srv_rdata = struct.pack("!HHH", 0, 0, 56700) + srv_target
+    body = body[:-2] + struct.pack("!H", len(srv_rdata)) + srv_rdata
+
+    # Answer 3: TXT record
+    txt_name = b"\x0cD073D5882C19\x05_lifx\x04_udp\x05local\x00"
+    body += txt_name
+    txt_strings = [
+        "tm=1",
+        "cm=0",
+        "cnt=5",
+        "ts=1753699325000000000",
+        "fw=4.112",
+        "p=222",
+        "v=1",
+        "id=d073d5882c19",
+    ]
+    txt_rdata = b""
+    for s in txt_strings:
+        encoded = s.encode("utf-8")
+        txt_rdata += bytes([len(encoded)]) + encoded
+    body += struct.pack("!HHIH", 16, 0x8001, 4500, len(txt_rdata))  # TXT
+    body += txt_rdata
+
+    # Additional: A record - D073D5882C19.local -> 192.168.19.185
+    a_name = b"\x0cD073D5882C19\x05local\x00"
+    body += a_name
+    body += struct.pack("!HHIH", 1, 0x8001, 120, 4)  # A record
+    body += bytes([192, 168, 19, 185])
+
+    return header + body

--- a/tests/test_network/test_mdns/test_discovery.py
+++ b/tests/test_network/test_mdns/test_discovery.py
@@ -1,0 +1,483 @@
+"""Tests for mDNS discovery functions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lifx.devices.ceiling import CeilingLight
+from lifx.devices.hev import HevLight
+from lifx.devices.infrared import InfraredLight
+from lifx.devices.light import Light
+from lifx.devices.matrix import MatrixLight
+from lifx.devices.multizone import MultiZoneLight
+from lifx.network.mdns.discovery import (
+    _extract_lifx_info,
+    create_device_from_record,
+)
+from lifx.network.mdns.dns import DnsResourceRecord, SrvData, TxtData
+from lifx.network.mdns.types import LifxServiceRecord
+
+
+class TestExtractLifxInfo:
+    """Tests for _extract_lifx_info helper function."""
+
+    def test_extract_with_all_records(self) -> None:
+        """Test extraction with TXT, SRV, and A records."""
+        txt_data = TxtData(
+            strings=["id=d073d5123456", "p=27", "fw=4.112"],
+            pairs={"id": "d073d5123456", "p": "27", "fw": "4.112"},
+        )
+        srv_data = SrvData(priority=0, weight=0, port=56700, target="host.local")
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 16, 1, 120, b"", txt_data),
+            DnsResourceRecord("test._lifx._udp.local", 33, 1, 120, b"", srv_data),
+            DnsResourceRecord("host.local", 1, 1, 120, b"", "192.168.1.100"),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is not None
+        assert result.serial == "d073d5123456"
+        assert result.ip == "192.168.1.100"  # From A record
+        assert result.port == 56700  # From SRV record
+        assert result.product_id == 27
+        assert result.firmware == "4.112"
+
+    def test_extract_with_txt_only(self) -> None:
+        """Test extraction with only TXT record."""
+        txt_data = TxtData(
+            strings=["id=d073d5123456", "p=27", "fw=4.112"],
+            pairs={"id": "d073d5123456", "p": "27", "fw": "4.112"},
+        )
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 16, 1, 120, b"", txt_data),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is not None
+        assert result.serial == "d073d5123456"
+        assert result.ip == "192.168.1.50"  # From source IP
+        assert result.port == 56700  # Default
+        assert result.product_id == 27
+
+    def test_extract_missing_serial(self) -> None:
+        """Test extraction fails without serial."""
+        txt_data = TxtData(
+            strings=["p=27", "fw=4.112"],
+            pairs={"p": "27", "fw": "4.112"},
+        )
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 16, 1, 120, b"", txt_data),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is None
+
+    def test_extract_missing_product_id(self) -> None:
+        """Test extraction fails without product ID."""
+        txt_data = TxtData(
+            strings=["id=d073d5123456", "fw=4.112"],
+            pairs={"id": "d073d5123456", "fw": "4.112"},
+        )
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 16, 1, 120, b"", txt_data),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is None
+
+    def test_extract_invalid_product_id(self) -> None:
+        """Test extraction fails with non-numeric product ID."""
+        txt_data = TxtData(
+            strings=["id=d073d5123456", "p=abc", "fw=4.112"],
+            pairs={"id": "d073d5123456", "p": "abc", "fw": "4.112"},
+        )
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 16, 1, 120, b"", txt_data),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is None
+
+    def test_extract_no_txt_record(self) -> None:
+        """Test extraction fails without TXT record."""
+        srv_data = SrvData(priority=0, weight=0, port=56700, target="host.local")
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 33, 1, 120, b"", srv_data),
+            DnsResourceRecord("host.local", 1, 1, 120, b"", "192.168.1.100"),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is None
+
+    def test_extract_serial_lowercase(self) -> None:
+        """Test that serial is lowercased."""
+        txt_data = TxtData(
+            strings=["id=D073D5AABBCC", "p=27"],
+            pairs={"id": "D073D5AABBCC", "p": "27"},
+        )
+
+        records = [
+            DnsResourceRecord("test._lifx._udp.local", 16, 1, 120, b"", txt_data),
+        ]
+
+        result = _extract_lifx_info(records, "192.168.1.50")
+
+        assert result is not None
+        assert result.serial == "d073d5aabbcc"
+
+
+class TestCreateDeviceFromRecord:
+    """Tests for create_device_from_record function."""
+
+    def test_create_light_device(self) -> None:
+        """Test creating a basic Light device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,  # LIFX A19 - basic light
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is not None
+        assert isinstance(device, Light)
+        assert device.serial == "d073d5123456"
+        assert device.ip == "192.168.1.100"
+        assert device.port == 56700
+
+    def test_create_multizone_device(self) -> None:
+        """Test creating a MultiZoneLight device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=31,  # LIFX Z - multizone
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is not None
+        assert isinstance(device, MultiZoneLight)
+
+    def test_create_matrix_device(self) -> None:
+        """Test creating a MatrixLight device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=55,  # LIFX Tile - matrix
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is not None
+        assert isinstance(device, MatrixLight)
+
+    def test_create_ceiling_device(self) -> None:
+        """Test creating a CeilingLight device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=176,  # LIFX Ceiling US
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is not None
+        assert isinstance(device, CeilingLight)
+
+    def test_create_infrared_device(self) -> None:
+        """Test creating an InfraredLight device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=29,  # LIFX+ A19 - has infrared
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is not None
+        assert isinstance(device, InfraredLight)
+
+    def test_create_hev_device(self) -> None:
+        """Test creating a HevLight device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=90,  # LIFX Clean - has HEV
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is not None
+        assert isinstance(device, HevLight)
+
+    def test_relay_device_returns_none(self) -> None:
+        """Test that relay devices return None."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=70,  # LIFX Switch - relay only
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record)
+
+        assert device is None
+
+    def test_device_timeout_and_retries(self) -> None:
+        """Test that timeout and retries are passed to device."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,
+            firmware="4.112",
+        )
+
+        device = create_device_from_record(record, timeout=30.0, max_retries=5)
+
+        assert device is not None
+        # Check that timeout/retries were passed to the connection
+        assert device.connection.timeout == 30.0
+        assert device.connection.max_retries == 5
+
+
+class TestLifxServiceRecord:
+    """Tests for LifxServiceRecord dataclass."""
+
+    def test_hash_by_serial(self) -> None:
+        """Test that records hash by serial."""
+        record1 = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,
+            firmware="4.112",
+        )
+        record2 = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.200",  # Different IP
+            port=56701,  # Different port
+            product_id=28,  # Different product
+            firmware="4.113",  # Different firmware
+        )
+
+        assert hash(record1) == hash(record2)
+
+    def test_equality_by_serial(self) -> None:
+        """Test that records are equal by serial."""
+        record1 = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,
+            firmware="4.112",
+        )
+        record2 = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.200",
+            port=56701,
+            product_id=28,
+            firmware="4.113",
+        )
+        record3 = LifxServiceRecord(
+            serial="d073d5654321",  # Different serial
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,
+            firmware="4.112",
+        )
+
+        assert record1 == record2
+        assert record1 != record3
+
+    def test_immutable(self) -> None:
+        """Test that records are immutable (frozen dataclass)."""
+        record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,
+            firmware="4.112",
+        )
+
+        with pytest.raises(AttributeError):
+            record.serial = "new_serial"  # type: ignore[misc]
+
+
+class TestDiscoverLifxServices:
+    """Tests for discover_lifx_services function."""
+
+    @pytest.mark.asyncio
+    async def test_discover_yields_records(self) -> None:
+        """Test that discovery yields service records."""
+        from lifx.network.mdns.discovery import discover_lifx_services
+
+        # Create mock response data
+        mock_response_data = b"\x00" * 100  # Placeholder
+
+        # Create mock records
+        txt_data = TxtData(
+            strings=["id=d073d5123456", "p=27", "fw=4.112"],
+            pairs={"id": "d073d5123456", "p": "27", "fw": "4.112"},
+        )
+
+        mock_parsed_response = MagicMock()
+        mock_parsed_response.header.is_response = True
+        mock_parsed_response.records = [
+            MagicMock(
+                rtype=12, name="_lifx._udp.local", parsed_data="device._lifx._udp.local"
+            ),
+            MagicMock(rtype=16, parsed_data=txt_data),
+        ]
+
+        with patch("lifx.network.mdns.discovery.MdnsTransport") as mock_transport_cls:
+            mock_transport = AsyncMock()
+            mock_transport_cls.return_value.__aenter__.return_value = mock_transport
+
+            # First receive returns data, second raises timeout
+            mock_transport.receive.side_effect = [
+                (mock_response_data, ("192.168.1.100", 5353)),
+                Exception("timeout"),
+            ]
+
+            with patch("lifx.network.mdns.discovery.parse_dns_response") as mock_parse:
+                mock_parse.return_value = mock_parsed_response
+
+                records = []
+                async for record in discover_lifx_services(timeout=0.1):
+                    records.append(record)
+
+                assert len(records) == 1
+                assert records[0].serial == "d073d5123456"
+
+    @pytest.mark.asyncio
+    async def test_discover_deduplicates_by_serial(self) -> None:
+        """Test that discovery deduplicates by serial."""
+        from lifx.network.mdns.discovery import discover_lifx_services
+
+        txt_data = TxtData(
+            strings=["id=d073d5123456", "p=27", "fw=4.112"],
+            pairs={"id": "d073d5123456", "p": "27", "fw": "4.112"},
+        )
+
+        mock_parsed_response = MagicMock()
+        mock_parsed_response.header.is_response = True
+        mock_parsed_response.records = [
+            MagicMock(
+                rtype=12, name="_lifx._udp.local", parsed_data="device._lifx._udp.local"
+            ),
+            MagicMock(rtype=16, parsed_data=txt_data),
+        ]
+
+        with patch("lifx.network.mdns.discovery.MdnsTransport") as mock_transport_cls:
+            mock_transport = AsyncMock()
+            mock_transport_cls.return_value.__aenter__.return_value = mock_transport
+
+            # Return same device twice, then timeout
+            mock_transport.receive.side_effect = [
+                (b"\x00" * 100, ("192.168.1.100", 5353)),
+                (b"\x00" * 100, ("192.168.1.100", 5353)),
+                Exception("timeout"),
+            ]
+
+            with patch("lifx.network.mdns.discovery.parse_dns_response") as mock_parse:
+                mock_parse.return_value = mock_parsed_response
+
+                records = []
+                async for record in discover_lifx_services(timeout=0.1):
+                    records.append(record)
+
+                # Should only get one record despite two responses
+                assert len(records) == 1
+
+
+class TestDiscoverDevicesMdns:
+    """Tests for discover_devices_mdns function."""
+
+    @pytest.mark.asyncio
+    async def test_discover_yields_device_instances(self) -> None:
+        """Test that discovery yields device instances."""
+        from lifx.network.mdns.discovery import discover_devices_mdns
+
+        # Create a mock service record
+        mock_record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=27,
+            firmware="4.112",
+        )
+
+        with patch(
+            "lifx.network.mdns.discovery.discover_lifx_services"
+        ) as mock_discover:
+
+            async def mock_generator():
+                yield mock_record
+
+            mock_discover.return_value = mock_generator()
+
+            devices = []
+            async for device in discover_devices_mdns(timeout=0.1):
+                devices.append(device)
+
+            assert len(devices) == 1
+            assert isinstance(devices[0], Light)
+            assert devices[0].serial == "d073d5123456"
+
+    @pytest.mark.asyncio
+    async def test_discover_filters_relay_devices(self) -> None:
+        """Test that relay devices are filtered out."""
+        from lifx.network.mdns.discovery import discover_devices_mdns
+
+        # Create a mock relay device record
+        mock_record = LifxServiceRecord(
+            serial="d073d5123456",
+            ip="192.168.1.100",
+            port=56700,
+            product_id=70,  # LIFX Switch - relay only
+            firmware="4.112",
+        )
+
+        with patch(
+            "lifx.network.mdns.discovery.discover_lifx_services"
+        ) as mock_discover:
+
+            async def mock_generator():
+                yield mock_record
+
+            mock_discover.return_value = mock_generator()
+
+            devices = []
+            async for device in discover_devices_mdns(timeout=0.1):
+                devices.append(device)
+
+            # Relay device should be filtered out
+            assert len(devices) == 0

--- a/tests/test_network/test_mdns/test_dns.py
+++ b/tests/test_network/test_mdns/test_dns.py
@@ -1,0 +1,304 @@
+"""Tests for DNS wire format parser."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from lifx.network.mdns.dns import (
+    DNS_TYPE_A,
+    DNS_TYPE_PTR,
+    DNS_TYPE_SRV,
+    DNS_TYPE_TXT,
+    DnsHeader,
+    SrvData,
+    TxtData,
+    build_ptr_query,
+    parse_dns_response,
+    parse_name,
+    parse_txt_record,
+)
+
+
+class TestDnsHeader:
+    """Tests for DnsHeader parsing."""
+
+    def test_parse_query_header(self) -> None:
+        """Test parsing a query header."""
+        # ID=0x1234, query (no QR bit), 1 question
+        data = struct.pack("!HHHHHH", 0x1234, 0x0000, 1, 0, 0, 0)
+        header = DnsHeader.parse(data)
+
+        assert header.id == 0x1234
+        assert header.is_response is False
+        assert header.qd_count == 1
+        assert header.an_count == 0
+
+    def test_parse_response_header(self) -> None:
+        """Test parsing a response header."""
+        # ID=0, response (QR=1, AA=1), 0 questions, 3 answers, 0 auth, 2 additional
+        data = struct.pack("!HHHHHH", 0, 0x8400, 0, 3, 0, 2)
+        header = DnsHeader.parse(data)
+
+        assert header.id == 0
+        assert header.is_response is True
+        assert header.qd_count == 0
+        assert header.an_count == 3
+        assert header.ns_count == 0
+        assert header.ar_count == 2
+
+    def test_parse_header_too_short(self) -> None:
+        """Test that short data raises ValueError."""
+        with pytest.raises(ValueError, match="too short"):
+            DnsHeader.parse(b"\x00" * 10)
+
+
+class TestParseName:
+    """Tests for DNS name parsing."""
+
+    def test_parse_simple_name(self) -> None:
+        """Test parsing a simple name without compression."""
+        # test.local
+        data = b"\x04test\x05local\x00"
+        name, offset = parse_name(data, 0)
+
+        assert name == "test.local"
+        assert offset == len(data)
+
+    def test_parse_name_with_multiple_labels(self) -> None:
+        """Test parsing a name with multiple labels."""
+        # _lifx._udp.local
+        data = b"\x05_lifx\x04_udp\x05local\x00"
+        name, offset = parse_name(data, 0)
+
+        assert name == "_lifx._udp.local"
+        assert offset == len(data)
+
+    def test_parse_name_with_compression(self) -> None:
+        """Test parsing a name with compression pointer."""
+        # First name at offset 0: test.local
+        # Second name at offset X: foo -> pointer to offset 5 (local)
+        data = b"\x04test\x05local\x00\x03foo\xc0\x05"
+        #       0-4    5-10   11  12-15 16-17
+
+        # Parse second name starting at offset 12
+        name, offset = parse_name(data, 12)
+
+        assert name == "foo.local"
+        assert offset == 18  # After the compression pointer
+
+    def test_parse_name_root(self) -> None:
+        """Test parsing the root domain (just null byte)."""
+        data = b"\x00"
+        name, offset = parse_name(data, 0)
+
+        assert name == "."
+        assert offset == 1
+
+    def test_parse_name_at_offset(self) -> None:
+        """Test parsing a name starting at non-zero offset."""
+        # Some prefix data, then test.local
+        data = b"\x00\x00\x00\x04test\x05local\x00"
+        name, offset = parse_name(data, 3)
+
+        assert name == "test.local"
+        assert offset == len(data)
+
+    def test_parse_name_off_end(self) -> None:
+        """Test that parsing off the end raises ValueError."""
+        data = b"\x04test"  # Incomplete - missing rest of label and null
+        with pytest.raises(ValueError):
+            parse_name(data, 0)
+
+    def test_parse_name_too_many_jumps(self) -> None:
+        """Test that circular compression pointers are detected."""
+        # Create circular pointer: points to itself
+        data = b"\xc0\x00"  # Pointer at offset 0 pointing to offset 0
+        with pytest.raises(ValueError, match="Too many"):
+            parse_name(data, 0)
+
+
+class TestParseTxtRecord:
+    """Tests for TXT record parsing."""
+
+    def test_parse_lifx_txt(self, sample_txt_data: bytes) -> None:
+        """Test parsing LIFX TXT record format."""
+        result = parse_txt_record(sample_txt_data)
+
+        assert isinstance(result, TxtData)
+        assert "p=222" in result.strings
+        assert "id=d073d5882c19" in result.strings
+        assert result.pairs["p"] == "222"
+        assert result.pairs["id"] == "d073d5882c19"
+        assert result.pairs["fw"] == "4.112"
+        assert result.pairs["cnt"] == "5"
+
+    def test_parse_empty_txt(self) -> None:
+        """Test parsing empty TXT data."""
+        result = parse_txt_record(b"")
+        assert result.strings == []
+        assert result.pairs == {}
+
+    def test_parse_single_string(self) -> None:
+        """Test parsing TXT with single string."""
+        data = b"\x05hello"
+        result = parse_txt_record(data)
+
+        assert result.strings == ["hello"]
+        assert result.pairs == {}
+
+    def test_parse_key_value_pair(self) -> None:
+        """Test parsing TXT with key=value format."""
+        data = b"\x09foo=hello"
+        result = parse_txt_record(data)
+
+        assert result.strings == ["foo=hello"]
+        assert result.pairs["foo"] == "hello"
+
+    def test_parse_empty_value(self) -> None:
+        """Test parsing key with empty value."""
+        data = b"\x04foo="
+        result = parse_txt_record(data)
+
+        assert result.pairs["foo"] == ""
+
+
+class TestBuildPtrQuery:
+    """Tests for building PTR queries."""
+
+    def test_build_lifx_query(self) -> None:
+        """Test building a query for _lifx._udp.local."""
+        query = build_ptr_query("_lifx._udp.local")
+
+        # Should be a valid DNS query
+        header = DnsHeader.parse(query)
+        assert header.id == 0  # mDNS uses ID=0
+        assert header.is_response is False
+        assert header.qd_count == 1
+
+        # Parse the question
+        name, offset = parse_name(query, 12)
+        assert name == "_lifx._udp.local"
+
+        # Check QTYPE and QCLASS
+        qtype, qclass = struct.unpack("!HH", query[offset : offset + 4])
+        assert qtype == DNS_TYPE_PTR
+        assert qclass == 1  # IN
+
+    def test_build_custom_service_query(self) -> None:
+        """Test building a query for a custom service."""
+        query = build_ptr_query("_http._tcp.local")
+
+        name, _ = parse_name(query, 12)
+        assert name == "_http._tcp.local"
+
+
+class TestParseDnsResponse:
+    """Tests for complete DNS response parsing."""
+
+    def test_parse_simple_response(self, simple_dns_response: bytes) -> None:
+        """Test parsing a simple DNS response with one A record."""
+        result = parse_dns_response(simple_dns_response)
+
+        assert result.header.is_response is True
+        assert result.header.an_count == 1
+        assert len(result.records) == 1
+
+        record = result.records[0]
+        assert record.name == "test.local"
+        assert record.rtype == DNS_TYPE_A
+        assert record.parsed_data == "192.168.1.1"
+
+    def test_parse_lifx_response(self, lifx_dns_response: bytes) -> None:
+        """Test parsing a realistic LIFX mDNS response."""
+        result = parse_dns_response(lifx_dns_response)
+
+        assert result.header.is_response is True
+        # Should have PTR, SRV, TXT in answers + A in additional
+        assert len(result.records) == 4
+
+        # Find specific records by type
+        ptr_records = [r for r in result.records if r.rtype == DNS_TYPE_PTR]
+        srv_records = [r for r in result.records if r.rtype == DNS_TYPE_SRV]
+        txt_records = [r for r in result.records if r.rtype == DNS_TYPE_TXT]
+        a_records = [r for r in result.records if r.rtype == DNS_TYPE_A]
+
+        assert len(ptr_records) == 1
+        assert len(srv_records) == 1
+        assert len(txt_records) == 1
+        assert len(a_records) == 1
+
+        # Check PTR record
+        ptr = ptr_records[0]
+        assert "_lifx._udp.local" in ptr.name
+        assert "D073D5882C19" in ptr.parsed_data
+
+        # Check SRV record
+        srv = srv_records[0]
+        assert isinstance(srv.parsed_data, SrvData)
+        assert srv.parsed_data.port == 56700
+        assert "D073D5882C19" in srv.parsed_data.target
+
+        # Check TXT record
+        txt = txt_records[0]
+        assert isinstance(txt.parsed_data, TxtData)
+        assert txt.parsed_data.pairs["p"] == "222"
+        assert txt.parsed_data.pairs["id"] == "d073d5882c19"
+        assert txt.parsed_data.pairs["fw"] == "4.112"
+
+        # Check A record
+        a = a_records[0]
+        assert a.parsed_data == "192.168.19.185"
+
+    def test_parse_response_header_only(self) -> None:
+        """Test parsing a response with no records."""
+        # Header only, 0 records
+        data = struct.pack("!HHHHHH", 0, 0x8400, 0, 0, 0, 0)
+        result = parse_dns_response(data)
+
+        assert result.header.is_response is True
+        assert len(result.records) == 0
+
+    def test_cache_flush_bit(self, simple_dns_response: bytes) -> None:
+        """Test that cache flush bit is correctly detected."""
+        # Modify the simple response to set cache-flush bit
+        # Class field is at offset after name + 2 bytes (type)
+        # name "test.local\0" = 12 bytes, then type(2) + class(2)
+        header_len = 12
+        name_len = 12  # \x04test\x05local\x00
+        class_offset = header_len + name_len + 2
+
+        # Set cache-flush bit (0x8001 instead of 0x0001)
+        modified = bytearray(simple_dns_response)
+        modified[class_offset : class_offset + 2] = struct.pack("!H", 0x8001)
+
+        result = parse_dns_response(bytes(modified))
+        assert result.records[0].cache_flush is True
+
+
+class TestDnsResourceRecord:
+    """Tests for DnsResourceRecord properties."""
+
+    def test_type_name_known(self) -> None:
+        """Test type_name for known types."""
+        from lifx.network.mdns.dns import DnsResourceRecord
+
+        record = DnsResourceRecord("test.local", DNS_TYPE_A, 1, 120, b"")
+        assert record.type_name == "A"
+
+        record = DnsResourceRecord("test.local", DNS_TYPE_PTR, 1, 120, b"")
+        assert record.type_name == "PTR"
+
+        record = DnsResourceRecord("test.local", DNS_TYPE_TXT, 1, 120, b"")
+        assert record.type_name == "TXT"
+
+        record = DnsResourceRecord("test.local", DNS_TYPE_SRV, 1, 120, b"")
+        assert record.type_name == "SRV"
+
+    def test_type_name_unknown(self) -> None:
+        """Test type_name for unknown types."""
+        from lifx.network.mdns.dns import DnsResourceRecord
+
+        record = DnsResourceRecord("test.local", 999, 1, 120, b"")
+        assert record.type_name == "TYPE999"

--- a/tests/test_network/test_mdns/test_transport.py
+++ b/tests/test_network/test_mdns/test_transport.py
@@ -1,0 +1,247 @@
+"""Tests for mDNS transport."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lifx.const import MDNS_ADDRESS, MDNS_PORT
+from lifx.exceptions import LifxNetworkError, LifxTimeoutError
+from lifx.network.mdns.transport import MdnsTransport
+
+
+class TestMdnsTransportInit:
+    """Tests for MdnsTransport initialization."""
+
+    def test_initial_state(self) -> None:
+        """Test transport initializes in closed state."""
+        transport = MdnsTransport()
+
+        assert transport.is_open is False
+        assert transport._protocol is None
+        assert transport._transport is None
+        assert transport._socket is None
+
+
+class TestMdnsTransportContextManager:
+    """Tests for async context manager."""
+
+    @pytest.mark.asyncio
+    async def test_context_manager_opens_and_closes(self) -> None:
+        """Test that context manager opens on enter and closes on exit."""
+        transport = MdnsTransport()
+
+        with patch.object(transport, "open", new_callable=AsyncMock) as mock_open:
+            with patch.object(transport, "close", new_callable=AsyncMock) as mock_close:
+                async with transport:
+                    mock_open.assert_called_once()
+                    mock_close.assert_not_called()
+
+                mock_close.assert_called_once()
+
+
+class TestMdnsTransportSend:
+    """Tests for sending data."""
+
+    @pytest.mark.asyncio
+    async def test_send_not_open_raises(self) -> None:
+        """Test that send raises when socket is not open."""
+        transport = MdnsTransport()
+
+        with pytest.raises(LifxNetworkError, match="Socket not open"):
+            await transport.send(b"test")
+
+    @pytest.mark.asyncio
+    async def test_send_default_address(self) -> None:
+        """Test that send uses mDNS multicast address by default."""
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._transport = MagicMock()
+
+        await transport.send(b"test")
+
+        transport._transport.sendto.assert_called_once_with(
+            b"test", (MDNS_ADDRESS, MDNS_PORT)
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_custom_address(self) -> None:
+        """Test that send can use a custom address."""
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._transport = MagicMock()
+
+        await transport.send(b"test", ("192.168.1.1", 5353))
+
+        transport._transport.sendto.assert_called_once_with(
+            b"test", ("192.168.1.1", 5353)
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_os_error_raises(self) -> None:
+        """Test that OSError is wrapped in LifxNetworkError."""
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._transport = MagicMock()
+        transport._transport.sendto.side_effect = OSError("Network error")
+
+        with pytest.raises(LifxNetworkError, match="Failed to send"):
+            await transport.send(b"test")
+
+
+class TestMdnsTransportReceive:
+    """Tests for receiving data."""
+
+    @pytest.mark.asyncio
+    async def test_receive_not_open_raises(self) -> None:
+        """Test that receive raises when socket is not open."""
+        transport = MdnsTransport()
+
+        with pytest.raises(LifxNetworkError, match="Socket not open"):
+            await transport.receive()
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_raises(self) -> None:
+        """Test that receive raises LifxTimeoutError on timeout."""
+        import asyncio
+
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._protocol.queue = asyncio.Queue()
+
+        with pytest.raises(LifxTimeoutError, match="No mDNS data received"):
+            await transport.receive(timeout=0.01)
+
+    @pytest.mark.asyncio
+    async def test_receive_returns_data(self) -> None:
+        """Test that receive returns data from queue."""
+        import asyncio
+
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._protocol.queue = asyncio.Queue()
+
+        # Put test data in queue
+        test_data = b"test response"
+        test_addr = ("192.168.1.1", 5353)
+        await transport._protocol.queue.put((test_data, test_addr))
+
+        data, addr = await transport.receive()
+
+        assert data == test_data
+        assert addr == test_addr
+
+
+class TestMdnsTransportClose:
+    """Tests for closing transport."""
+
+    @pytest.mark.asyncio
+    async def test_close_when_not_open(self) -> None:
+        """Test that close does nothing when not open."""
+        transport = MdnsTransport()
+
+        # Should not raise
+        await transport.close()
+
+        assert transport.is_open is False
+
+    @pytest.mark.asyncio
+    async def test_close_clears_state(self) -> None:
+        """Test that close clears internal state."""
+        import socket
+
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._transport = MagicMock()
+        transport._socket = MagicMock(spec=socket.socket)
+
+        await transport.close()
+
+        assert transport._protocol is None
+        assert transport._transport is None
+        assert transport._socket is None
+        assert transport.is_open is False
+
+    @pytest.mark.asyncio
+    async def test_close_leaves_multicast_group(self) -> None:
+        """Test that close leaves the multicast group."""
+        import socket
+
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._transport = MagicMock()
+        mock_socket = MagicMock(spec=socket.socket)
+        transport._socket = mock_socket
+
+        await transport.close()
+
+        # Should have called setsockopt to drop membership
+        mock_socket.setsockopt.assert_called()
+
+
+class TestMdnsTransportIsOpen:
+    """Tests for is_open property."""
+
+    def test_is_open_false_when_no_protocol(self) -> None:
+        """Test is_open is False when protocol is None."""
+        transport = MdnsTransport()
+        assert transport.is_open is False
+
+    def test_is_open_true_when_protocol_set(self) -> None:
+        """Test is_open is True when protocol is set."""
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        assert transport.is_open is True
+
+
+class TestMdnsProtocol:
+    """Tests for the internal _MdnsProtocol class."""
+
+    def test_datagram_received_queues_data(self) -> None:
+        """Test that received datagrams are queued."""
+
+        from lifx.network.mdns.transport import _MdnsProtocol
+
+        protocol = _MdnsProtocol()
+
+        # Simulate receiving a datagram
+        test_data = b"test data"
+        test_addr = ("192.168.1.1", 5353)
+        protocol.datagram_received(test_data, test_addr)
+
+        # Check data is in queue
+        assert not protocol.queue.empty()
+        data, addr = protocol.queue.get_nowait()
+        assert data == test_data
+        assert addr == test_addr
+
+    def test_connection_made_stores_transport(self) -> None:
+        """Test that connection_made stores the transport."""
+        from lifx.network.mdns.transport import _MdnsProtocol
+
+        protocol = _MdnsProtocol()
+        mock_transport = MagicMock()
+
+        protocol.connection_made(mock_transport)
+
+        assert protocol._transport is mock_transport
+
+    def test_error_received_does_not_raise(self) -> None:
+        """Test that error_received handles errors gracefully."""
+        from lifx.network.mdns.transport import _MdnsProtocol
+
+        protocol = _MdnsProtocol()
+
+        # Should not raise
+        protocol.error_received(OSError("Test error"))
+
+    def test_connection_lost_does_not_raise(self) -> None:
+        """Test that connection_lost handles disconnection gracefully."""
+        from lifx.network.mdns.transport import _MdnsProtocol
+
+        protocol = _MdnsProtocol()
+
+        # Should not raise
+        protocol.connection_lost(None)
+        protocol.connection_lost(OSError("Disconnected"))

--- a/tests/test_network/test_mdns/test_transport.py
+++ b/tests/test_network/test_mdns/test_transport.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lifx.const import MDNS_ADDRESS, MDNS_PORT
 from lifx.exceptions import LifxNetworkError, LifxTimeoutError
-from lifx.network.mdns.transport import MdnsTransport
+from lifx.network.mdns.transport import MdnsTransport, _MdnsProtocol
 
 
 class TestMdnsTransportInit:
@@ -22,6 +24,148 @@ class TestMdnsTransportInit:
         assert transport._protocol is None
         assert transport._transport is None
         assert transport._socket is None
+
+
+class TestMdnsTransportOpen:
+    """Tests for MdnsTransport.open() method."""
+
+    @pytest.mark.asyncio
+    async def test_open_creates_socket_and_protocol(self) -> None:
+        """Test that open() creates socket, protocol, and transport."""
+        transport = MdnsTransport()
+
+        # Mock the socket and asyncio loop
+        mock_socket = MagicMock(spec=socket.socket)
+        mock_socket.getsockname.return_value = ("", MDNS_PORT)
+
+        mock_datagram_transport = MagicMock()
+
+        with patch("socket.socket", return_value=mock_socket):
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.create_datagram_endpoint = AsyncMock(
+                    return_value=(mock_datagram_transport, None)
+                )
+
+                await transport.open()
+
+                # Verify socket configuration
+                assert mock_socket.setsockopt.called
+                assert mock_socket.bind.called
+                assert mock_socket.setblocking.called
+
+                # Verify transport state
+                assert transport.is_open is True
+                assert transport._protocol is not None
+                assert transport._transport is mock_datagram_transport
+                assert transport._socket is mock_socket
+
+        await transport.close()
+
+    @pytest.mark.asyncio
+    async def test_open_already_open_does_nothing(self) -> None:
+        """Test that open() is idempotent when already open."""
+        transport = MdnsTransport()
+
+        # Set up as already open
+        transport._protocol = MagicMock()
+
+        # Should not raise and should return early
+        await transport.open()
+
+        # Protocol should still be the same mock
+        assert transport._protocol is not None
+
+    @pytest.mark.asyncio
+    async def test_open_ephemeral_port_fallback(self) -> None:
+        """Test that open() falls back to ephemeral port if MDNS_PORT is busy."""
+        transport = MdnsTransport()
+
+        mock_socket = MagicMock(spec=socket.socket)
+        # First bind fails, second succeeds
+        mock_socket.bind.side_effect = [OSError("Address in use"), None]
+        mock_socket.getsockname.return_value = ("", 12345)
+
+        mock_datagram_transport = MagicMock()
+
+        with patch("socket.socket", return_value=mock_socket):
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.create_datagram_endpoint = AsyncMock(
+                    return_value=(mock_datagram_transport, None)
+                )
+
+                await transport.open()
+
+                # Verify bind was called twice (once for MDNS_PORT, once for ephemeral)
+                assert mock_socket.bind.call_count == 2
+                # First call should be to MDNS_PORT
+                assert mock_socket.bind.call_args_list[0][0][0] == ("", MDNS_PORT)
+                # Second call should be to ephemeral port
+                assert mock_socket.bind.call_args_list[1][0][0] == ("", 0)
+
+                assert transport.is_open is True
+
+        await transport.close()
+
+    @pytest.mark.asyncio
+    async def test_open_reuseport_not_available(self) -> None:
+        """Test that open() handles SO_REUSEPORT not being available."""
+        transport = MdnsTransport()
+
+        mock_socket = MagicMock(spec=socket.socket)
+
+        # Make SO_REUSEPORT fail (common on some systems)
+        def mock_setsockopt(level: int, opt: int, value: int) -> None:
+            if hasattr(socket, "SO_REUSEPORT") and opt == socket.SO_REUSEPORT:
+                raise OSError("Protocol not available")
+
+        mock_socket.setsockopt.side_effect = mock_setsockopt
+        mock_socket.getsockname.return_value = ("", MDNS_PORT)
+
+        mock_datagram_transport = MagicMock()
+
+        with patch("socket.socket", return_value=mock_socket):
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.create_datagram_endpoint = AsyncMock(
+                    return_value=(mock_datagram_transport, None)
+                )
+
+                # Should not raise - SO_REUSEPORT failure is ignored
+                await transport.open()
+                assert transport.is_open is True
+
+        await transport.close()
+
+    @pytest.mark.asyncio
+    async def test_open_socket_creation_fails(self) -> None:
+        """Test that open() raises LifxNetworkError on socket failure."""
+        transport = MdnsTransport()
+
+        with patch("socket.socket", side_effect=OSError("Socket creation failed")):
+            with pytest.raises(LifxNetworkError, match="Failed to open mDNS socket"):
+                await transport.open()
+
+        assert transport.is_open is False
+
+    @pytest.mark.asyncio
+    async def test_open_multicast_join_fails(self) -> None:
+        """Test that open() raises LifxNetworkError if multicast join fails."""
+        transport = MdnsTransport()
+
+        mock_socket = MagicMock(spec=socket.socket)
+        mock_socket.getsockname.return_value = ("", MDNS_PORT)
+
+        # Make IP_ADD_MEMBERSHIP fail
+        def mock_setsockopt(level: int, opt: int, value: object) -> None:
+            if level == socket.IPPROTO_IP and opt == socket.IP_ADD_MEMBERSHIP:
+                raise OSError("Cannot join multicast group")
+
+        mock_socket.setsockopt.side_effect = mock_setsockopt
+
+        with patch("socket.socket", return_value=mock_socket):
+            with pytest.raises(LifxNetworkError, match="Failed to open mDNS socket"):
+                await transport.open()
+
+        assert transport.is_open is False
 
 
 class TestMdnsTransportContextManager:
@@ -39,6 +183,25 @@ class TestMdnsTransportContextManager:
                     mock_close.assert_not_called()
 
                 mock_close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_real_open_close(self) -> None:
+        """Test context manager with real open/close (mocked socket)."""
+        mock_socket = MagicMock(spec=socket.socket)
+        mock_socket.getsockname.return_value = ("", MDNS_PORT)
+        mock_datagram_transport = MagicMock()
+
+        with patch("socket.socket", return_value=mock_socket):
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.create_datagram_endpoint = AsyncMock(
+                    return_value=(mock_datagram_transport, None)
+                )
+
+                async with MdnsTransport() as transport:
+                    assert transport.is_open is True
+
+                # After exiting, transport should be closed
+                assert transport.is_open is False
 
 
 class TestMdnsTransportSend:
@@ -116,8 +279,6 @@ class TestMdnsTransportReceive:
     @pytest.mark.asyncio
     async def test_receive_returns_data(self) -> None:
         """Test that receive returns data from queue."""
-        import asyncio
-
         transport = MdnsTransport()
         transport._protocol = MagicMock()
         transport._protocol.queue = asyncio.Queue()
@@ -131,6 +292,20 @@ class TestMdnsTransportReceive:
 
         assert data == test_data
         assert addr == test_addr
+
+    @pytest.mark.asyncio
+    async def test_receive_os_error_raises(self) -> None:
+        """Test that OSError in receive is wrapped in LifxNetworkError."""
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+
+        # Create a queue that raises OSError when getting
+        mock_queue = MagicMock()
+        mock_queue.get = AsyncMock(side_effect=OSError("Network error"))
+        transport._protocol.queue = mock_queue
+
+        with pytest.raises(LifxNetworkError, match="Failed to receive"):
+            await transport.receive()
 
 
 class TestMdnsTransportClose:
@@ -166,8 +341,6 @@ class TestMdnsTransportClose:
     @pytest.mark.asyncio
     async def test_close_leaves_multicast_group(self) -> None:
         """Test that close leaves the multicast group."""
-        import socket
-
         transport = MdnsTransport()
         transport._protocol = MagicMock()
         transport._transport = MagicMock()
@@ -178,6 +351,24 @@ class TestMdnsTransportClose:
 
         # Should have called setsockopt to drop membership
         mock_socket.setsockopt.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_close_ignores_multicast_leave_error(self) -> None:
+        """Test that close ignores errors when leaving multicast group."""
+        transport = MdnsTransport()
+        transport._protocol = MagicMock()
+        transport._transport = MagicMock()
+        mock_socket = MagicMock(spec=socket.socket)
+        # Make leaving multicast group fail
+        mock_socket.setsockopt.side_effect = OSError("Cannot leave group")
+        transport._socket = mock_socket
+
+        # Should not raise despite OSError
+        await transport.close()
+
+        # Transport should still be closed
+        assert transport.is_open is False
+        assert transport._socket is None
 
 
 class TestMdnsTransportIsOpen:
@@ -201,8 +392,6 @@ class TestMdnsProtocol:
     def test_datagram_received_queues_data(self) -> None:
         """Test that received datagrams are queued."""
 
-        from lifx.network.mdns.transport import _MdnsProtocol
-
         protocol = _MdnsProtocol()
 
         # Simulate receiving a datagram
@@ -218,7 +407,6 @@ class TestMdnsProtocol:
 
     def test_connection_made_stores_transport(self) -> None:
         """Test that connection_made stores the transport."""
-        from lifx.network.mdns.transport import _MdnsProtocol
 
         protocol = _MdnsProtocol()
         mock_transport = MagicMock()
@@ -229,7 +417,6 @@ class TestMdnsProtocol:
 
     def test_error_received_does_not_raise(self) -> None:
         """Test that error_received handles errors gracefully."""
-        from lifx.network.mdns.transport import _MdnsProtocol
 
         protocol = _MdnsProtocol()
 
@@ -238,7 +425,6 @@ class TestMdnsProtocol:
 
     def test_connection_lost_does_not_raise(self) -> None:
         """Test that connection_lost handles disconnection gracefully."""
-        from lifx.network.mdns.transport import _MdnsProtocol
 
         protocol = _MdnsProtocol()
 


### PR DESCRIPTION
Implement zero-dependency mDNS discovery using the _lifx._udp.local service type. This provides an alternative to UDP broadcast discovery with several advantages:

- Single network query instead of 1+N (one per device for type detection)
- Device type detection from TXT record (product ID) without extra queries
- Cross-subnet discovery possible with mDNS reflector

New APIs:
- discover_mdns(): High-level async generator yielding device instances
- discover_lifx_services(): Low-level async generator yielding raw records
- LifxServiceRecord: Dataclass with serial, ip, port, product_id, firmware

Implementation:
- Pure Python stdlib (socket, struct, asyncio) - no dependencies
- DNS wire format parser for PTR, SRV, A, TXT records
- MdnsTransport class for multicast UDP (224.0.0.251:5353)
- Dual timeout mechanism (idle + overall) matching existing discovery
- Device class selection using product registry (same priority as broadcast)

Includes 63 new tests, example script, and scripts/mdns_probe.py utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)