### PR TITLE
fix: handle asyncio.TimeoutError on Python 3.10

### DIFF
--- a/scripts/test_multiversion.py
+++ b/scripts/test_multiversion.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Multi-version Python test runner.
+
+This script runs the test suite against multiple Python versions to catch
+version-specific issues (like the asyncio.TimeoutError vs TimeoutError
+difference between Python 3.10 and 3.11+) before pushing to GitHub.
+
+Usage:
+    # Run tests on all supported versions (default)
+    uv run scripts/test_multiversion.py
+
+    # Run tests on specific versions only
+    uv run scripts/test_multiversion.py --versions 3.10 3.14
+
+    # Run with verbose pytest output
+    uv run scripts/test_multiversion.py -v
+
+    # Run specific test file/pattern
+    uv run scripts/test_multiversion.py -- tests/test_network/
+
+    # Quick mode: skip coverage
+    uv run scripts/test_multiversion.py --quick
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess  # nosec B404 - subprocess needed for running uv/pytest
+import sys
+import time
+from dataclasses import dataclass
+
+# Python versions supported by this project (from pyproject.toml)
+SUPPORTED_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+# Default: test all supported versions
+DEFAULT_VERSIONS = SUPPORTED_VERSIONS
+
+
+@dataclass
+class TestResult:
+    """Result of running tests on a specific Python version."""
+
+    version: str
+    success: bool
+    duration: float
+    output: str
+
+
+def check_python_available(version: str) -> bool:
+    """Check if a Python version is available via uv."""
+    result = subprocess.run(  # nosec B603 B607 - trusted uv command
+        ["uv", "python", "find", version],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def run_tests(
+    version: str,
+    pytest_args: list[str],
+    verbose: bool = False,
+    quick: bool = False,
+) -> TestResult:
+    """Run pytest on a specific Python version using uv."""
+    start_time = time.time()
+
+    cmd = [
+        "uv",
+        "run",
+        "--python",
+        version,
+        "--isolated",  # Use isolated environment to avoid conflicts
+        "pytest",
+    ]
+
+    # Add coverage unless in quick mode
+    if not quick:
+        cmd.extend(["--cov=lifx", "--cov-report=term-missing:skip-covered"])
+
+    # Add verbosity
+    if verbose:
+        cmd.append("-v")
+    else:
+        cmd.append("-q")
+
+    # Add any additional pytest arguments
+    cmd.extend(pytest_args)
+
+    # Ignore animation tests (uncommitted module with known issues)
+    cmd.extend(["--ignore=tests/test_animation"])
+
+    print(f"\n{'=' * 60}")
+    print(f"Running tests on Python {version}")
+    print(f"{'=' * 60}")
+    print(f"Command: {' '.join(cmd)}\n")
+
+    result = subprocess.run(  # nosec B603 - trusted uv/pytest command
+        cmd,
+        capture_output=not verbose,  # Show output in real-time if verbose
+        text=True,
+        cwd=subprocess.run(  # nosec B603 B607 - trusted git command
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip(),
+    )
+
+    duration = time.time() - start_time
+
+    output = ""
+    if not verbose:
+        output = result.stdout + result.stderr
+
+    return TestResult(
+        version=version,
+        success=result.returncode == 0,
+        duration=duration,
+        output=output,
+    )
+
+
+def main() -> int:
+    """Run tests across multiple Python versions."""
+    parser = argparse.ArgumentParser(
+        description="Run tests across multiple Python versions",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--versions",
+        nargs="+",
+        default=None,
+        help=f"Python versions to test (default: all supported: {SUPPORTED_VERSIONS})",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose pytest output",
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Quick mode: skip coverage for faster execution",
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs="*",
+        help="Additional arguments to pass to pytest",
+    )
+
+    args = parser.parse_args()
+
+    # Determine which versions to test
+    if args.versions:
+        versions = args.versions
+    else:
+        versions = DEFAULT_VERSIONS
+
+    # Validate versions
+    for version in versions:
+        if version not in SUPPORTED_VERSIONS:
+            print(
+                f"Warning: {version} is not in supported versions {SUPPORTED_VERSIONS}"
+            )
+
+    # Check availability
+    available_versions = []
+    missing_versions = []
+    for version in versions:
+        if check_python_available(version):
+            available_versions.append(version)
+        else:
+            missing_versions.append(version)
+
+    if missing_versions:
+        print(f"Missing Python versions: {missing_versions}")
+        print("Install with: uv python install " + " ".join(missing_versions))
+        if not available_versions:
+            return 1
+
+    print(f"Testing on Python versions: {available_versions}")
+
+    # Run tests
+    results: list[TestResult] = []
+    for version in available_versions:
+        result = run_tests(
+            version,
+            args.pytest_args,
+            verbose=args.verbose,
+            quick=args.quick,
+        )
+        results.append(result)
+
+        if not args.verbose:
+            # Show last few lines of output for quick feedback
+            lines = result.output.strip().split("\n")
+            for line in lines[-10:]:
+                print(line)
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print("SUMMARY")
+    print(f"{'=' * 60}")
+
+    all_passed = True
+    for result in results:
+        status = "✓ PASSED" if result.success else "✗ FAILED"
+        print(f"Python {result.version}: {status} ({result.duration:.1f}s)")
+        if not result.success:
+            all_passed = False
+
+    if missing_versions:
+        print(f"\nSkipped (not installed): {missing_versions}")
+
+    if all_passed:
+        print("\n✓ All tests passed across all Python versions!")
+        return 0
+    else:
+        print("\n✗ Some tests failed. Check output above for details.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lifx/const.py
+++ b/src/lifx/const.py
@@ -1,5 +1,7 @@
 # lifx-async constants
 
+import asyncio
+import sys
 import uuid
 from typing import Final
 
@@ -109,3 +111,19 @@ PROTOCOL_URL: Final[str] = (
 PRODUCTS_URL: Final[str] = (
     "https://raw.githubusercontent.com/LIFX/products/refs/heads/master/products.json"
 )
+
+# ============================================================================
+# Python Version Compatibility
+# ============================================================================
+
+# On Python 3.10, asyncio.wait_for() raises asyncio.TimeoutError which is NOT
+# a subclass of the built-in TimeoutError. In Python 3.11+, they are unified.
+# Use this tuple with `except TIMEOUT_ERRORS:` to catch timeouts from asyncio
+# operations on all supported Python versions.
+if sys.version_info < (3, 11):
+    TIMEOUT_ERRORS: Final[tuple[type[BaseException], ...]] = (
+        TimeoutError,
+        asyncio.TimeoutError,
+    )
+else:
+    TIMEOUT_ERRORS: Final[tuple[type[BaseException], ...]] = (TimeoutError,)

--- a/src/lifx/effects/colorloop.py
+++ b/src/lifx/effects/colorloop.py
@@ -11,7 +11,7 @@ import random
 from typing import TYPE_CHECKING
 
 from lifx.color import HSBK
-from lifx.const import KELVIN_NEUTRAL
+from lifx.const import KELVIN_NEUTRAL, TIMEOUT_ERRORS
 from lifx.effects.base import LIFXEffect
 
 if TYPE_CHECKING:
@@ -172,7 +172,7 @@ class EffectColorloop(LIFXEffect):
                     self._stop_event.wait(), timeout=iteration_period
                 )
                 break  # Stop event was set
-            except TimeoutError:
+            except TIMEOUT_ERRORS:
                 pass  # Normal - continue to next iteration
 
             iteration += 1

--- a/src/lifx/network/connection.py
+++ b/src/lifx/network/connection.py
@@ -17,6 +17,7 @@ from lifx.const import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
     LIFX_UDP_PORT,
+    TIMEOUT_ERRORS,
 )
 from lifx.exceptions import (
     LifxConnectionError,
@@ -193,7 +194,7 @@ class DeviceConnection:
                 await asyncio.wait_for(
                     self._receiver_task, timeout=_RECEIVER_SHUTDOWN_TIMEOUT
                 )
-            except TimeoutError:
+            except TIMEOUT_ERRORS:
                 self._receiver_task.cancel()
                 try:
                     await self._receiver_task
@@ -559,7 +560,7 @@ class DeviceConnection:
                             header, payload = await asyncio.wait_for(
                                 response_queue.get(), timeout=remaining_time
                             )
-                        except TimeoutError:
+                        except TIMEOUT_ERRORS:
                             if not has_yielded:
                                 # No response this attempt, retry
                                 raise TimeoutError(
@@ -603,7 +604,7 @@ class DeviceConnection:
 
                         # Continue loop to wait for more responses
 
-                except TimeoutError as e:
+                except TIMEOUT_ERRORS as e:
                     last_error = LifxTimeoutError(str(e))
                     if attempt < max_retries:
                         # Sleep with jitter before retry
@@ -702,7 +703,7 @@ class DeviceConnection:
                     header, _payload = await asyncio.wait_for(
                         response_queue.get(), timeout=current_timeout
                     )
-                except TimeoutError:
+                except TIMEOUT_ERRORS:
                     raise TimeoutError(
                         f"No acknowledgement within {current_timeout:.3f}s "
                         f"(attempt {attempt + 1}/{max_retries + 1})"
@@ -731,7 +732,7 @@ class DeviceConnection:
                 yield True
                 return
 
-            except TimeoutError as e:
+            except TIMEOUT_ERRORS as e:
                 last_error = LifxTimeoutError(str(e))
                 if attempt < max_retries:
                     # Sleep with jitter before retry

--- a/src/lifx/network/mdns/transport.py
+++ b/src/lifx/network/mdns/transport.py
@@ -13,7 +13,7 @@ import struct
 from asyncio import DatagramTransport
 from typing import TYPE_CHECKING
 
-from lifx.const import MDNS_ADDRESS, MDNS_PORT
+from lifx.const import MDNS_ADDRESS, MDNS_PORT, TIMEOUT_ERRORS
 from lifx.exceptions import LifxNetworkError, LifxTimeoutError
 
 if TYPE_CHECKING:
@@ -259,7 +259,7 @@ class MdnsTransport:
                 self._protocol.queue.get(), timeout=timeout
             )
             return data, addr
-        except TimeoutError as e:
+        except TIMEOUT_ERRORS as e:
             raise LifxTimeoutError(f"No mDNS data received within {timeout}s") from e
         except OSError as e:
             _LOGGER.debug(

--- a/src/lifx/network/transport.py
+++ b/src/lifx/network/transport.py
@@ -6,7 +6,12 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-from lifx.const import DEFAULT_IP_ADDRESS, MAX_PACKET_SIZE, MIN_PACKET_SIZE
+from lifx.const import (
+    DEFAULT_IP_ADDRESS,
+    MAX_PACKET_SIZE,
+    MIN_PACKET_SIZE,
+    TIMEOUT_ERRORS,
+)
 from lifx.exceptions import LifxNetworkError
 from lifx.exceptions import LifxTimeoutError as LifxTimeoutError
 
@@ -208,7 +213,7 @@ class UdpTransport:
             data, addr = await asyncio.wait_for(
                 self._protocol.queue.get(), timeout=timeout
             )
-        except TimeoutError as e:
+        except TIMEOUT_ERRORS as e:
             raise LifxTimeoutError(f"No data received within {timeout}s") from e
         except OSError as e:
             _LOGGER.error(
@@ -302,7 +307,7 @@ class UdpTransport:
                     continue
 
                 packets.append((data, addr))
-            except TimeoutError:
+            except TIMEOUT_ERRORS:
                 # Timeout is expected - return what we collected
                 break
             except OSError:

--- a/tests/test_api/test_api_apply_theme.py
+++ b/tests/test_api/test_api_apply_theme.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 
 from lifx.api import DeviceGroup
+from lifx.const import TIMEOUT_ERRORS
 from lifx.theme import ThemeLibrary
 
 
@@ -251,7 +252,7 @@ class TestDeviceGroupApplyTheme:
             # (will fail at connection level, but our method works)
             try:
                 await asyncio.wait_for(group.apply_theme(theme), timeout=0.1)
-            except TimeoutError:
+            except TIMEOUT_ERRORS:
                 # Expected - no real devices
                 pass
 


### PR DESCRIPTION
On Python 3.10, asyncio.wait_for() raises asyncio.TimeoutError which is a separate class from the built-in TimeoutError. In Python 3.11+, they were unified. This was causing unhandled exceptions on Python 3.10.

Added TIMEOUT_ERRORS constant in const.py that contains both exception types on Python 3.10 and just TimeoutError on Python 3.11+. Updated all except clauses that catch timeouts from asyncio operations.

Also added scripts/test_multiversion.py to run tests across all supported Python versions (3.10-3.14) locally before pushing, to catch similar version-specific issues in the future.