### PR TITLE
docs: remove reference to deleted FieldSerializer class

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -30,19 +30,6 @@ The LIFX protocol header structure (36 bytes).
       members_order: source
       show_if_no_docstring: false
 
-## Serializer
-
-Binary serialization and deserialization utilities.
-
-::: lifx.protocol.serializer.FieldSerializer
-    options:
-      show_root_heading: true
-      heading_level: 3
-      members_order: source
-      show_if_no_docstring: false
-      filters:
-        - "!^_"
-
 ## Protocol Types
 
 Common protocol type definitions and enums.
@@ -241,7 +228,6 @@ async def main():
 
 ```python
 from lifx.protocol.packets import DeviceSetLabel
-from lifx.protocol.serializer import Serializer
 
 # Create packet
 packet = DeviceSetLabel(label=b"Kitchen Light\0" + b"\0" * 19)


### PR DESCRIPTION
The FieldSerializer class was removed in commit 078aaf8 as unused code, but the documentation still referenced it, causing the docs build to fail.

- Remove the Serializer section from protocol.md
- Remove unused import from the Binary Serialization example