### PR TITLE
fix(tests): add pytest-timeout and retry flaky Windows emulator tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
 
     - name: Run unit tests
       run: uv run --frozen pytest
+      timeout-minutes: 10
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'
@@ -186,6 +187,7 @@ jobs:
 
     - name: Run unit tests
       run: uv run --frozen pytest
+      timeout-minutes: 10
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "pytest-retry>=1.7.0",
     "pytest-sugar>=1.1.1",
+    "pytest-timeout>=2.4.0",
     "pyyaml>=6.0.3",
     "ruff>=0.14.2",
     "typing-extensions>=4.15.0",
@@ -104,9 +105,12 @@ addopts = """\
     --cov-report=term-missing:skip-covered
     --junitxml=junit.xml -o junit_family=legacy
     --cov-context=test
+    --timeout=30
     """
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+timeout = 30
+timeout_method = "thread"
 markers = [
     "emulator: tests that require the lifx-emulator-core embedded emulator",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,31 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+# Give emulator tests more time on slow CI runners (especially Windows)
+_EMULATOR_TIMEOUT = 120
+
+_EMULATOR_FIXTURES = frozenset(
+    {
+        "emulator_port",
+        "emulator_server",
+        "emulator_devices",
+        "ceiling_device",
+        "switch_device",
+    }
+)
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Apply a longer timeout to emulator tests."""
+    for item in items:
+        uses_emulator = item.get_closest_marker("emulator") is not None or (
+            hasattr(item, "fixturenames")
+            and _EMULATOR_FIXTURES & set(item.fixturenames)
+        )
+        if uses_emulator and item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(_EMULATOR_TIMEOUT))
+
+
 def pytest_set_filtered_exceptions() -> list[type[Exception]]:
     """Configure pytest-retry to only retry on network-related exceptions.
 

--- a/tests/test_network/test_discovery_devices.py
+++ b/tests/test_network/test_discovery_devices.py
@@ -6,6 +6,8 @@ focusing on device creation, label-based discovery, and protocol edge cases.
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from lifx.devices.base import Device
@@ -17,6 +19,8 @@ from lifx.devices.multizone import MultiZoneLight
 from lifx.network.discovery import discover_devices
 
 
+@pytest.mark.emulator
+@pytest.mark.flaky(retries=2, delay=1, condition=sys.platform.startswith("win32"))
 class TestDiscoveredDeviceCreateDevice:
     """Tests for DiscoveredDevice.create_device() method.
 
@@ -105,6 +109,8 @@ class TestDiscoveredDeviceCreateDevice:
         assert "Light" in device_types and "InfraredLight" in device_types
 
 
+@pytest.mark.emulator
+@pytest.mark.flaky(retries=2, delay=1, condition=sys.platform.startswith("win32"))
 class TestDiscoveryEdgeCasesWithEmulator:
     """Additional edge case tests using the emulator server."""
 

--- a/tests/test_network/test_discovery_errors.py
+++ b/tests/test_network/test_discovery_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import struct
+import sys
 
 import pytest
 
@@ -47,6 +48,7 @@ class TestParseDeviceStateServiceErrors:
 
 
 @pytest.mark.emulator
+@pytest.mark.flaky(retries=2, delay=1, condition=sys.platform.startswith("win32"))
 class TestDiscoveryMalformedPackets:
     """Test discovery handling of malformed packets."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -438,6 +438,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-retry" },
     { name = "pytest-sugar" },
+    { name = "pytest-timeout" },
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "typing-extensions" },
@@ -459,6 +460,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-retry", specifier = ">=1.7.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", specifier = ">=0.14.2" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
@@ -1081,6 +1083,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `pytest-timeout` (30s default) to prevent tests from hanging indefinitely in CI
- Add 10-minute `timeout-minutes` to CI test workflow steps as a safety net
- Mark flaky Windows UDP-based emulator discovery tests with `@pytest.mark.flaky(retries=2, delay=1, condition=sys.platform.startswith("win32"))` so they only retry on Windows
- Add missing `@pytest.mark.emulator` markers to `TestDiscoveredDeviceCreateDevice` and `TestDiscoveryEdgeCasesWithEmulator`

## Test plan

- [x] All 1470 tests pass locally
- [ ] Verify Windows CI tests pass (or retry successfully) on Python 3.10-3.14
- [ ] Verify non-Windows CI tests are unaffected (no retries triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)