### PR TITLE
fix: move ceiling component state to CeilingLightState dataclass

### DIFF
--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -488,7 +488,8 @@ class CeilingLight(MatrixLight):
 
         # Update state — public fields, stored state, and last-known
         self.state.uplight_color = color
-        self.state.uplight_is_on = True  # brightness > 0 validated above
+        # brightness > 0 validated above; is_on also requires power
+        self.state.uplight_is_on = bool(self.state.power > 0)
         self.state.stored_uplight_color = color
         self.state.last_uplight_color = color
 
@@ -549,7 +550,8 @@ class CeilingLight(MatrixLight):
 
         # Update state — public fields, stored state, and last-known
         self.state.downlight_colors = list(downlight_colors)
-        self.state.downlight_is_on = True  # brightness > 0 validated above
+        # brightness > 0 validated above; is_on also requires power
+        self.state.downlight_is_on = bool(self.state.power > 0)
         self.state.stored_downlight_colors = list(downlight_colors)
         self.state.last_downlight_colors = list(downlight_colors)
 
@@ -614,9 +616,8 @@ class CeilingLight(MatrixLight):
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
             # Update state — public fields, stored state, and last-known
+            # (is_on flags deferred until after power-on succeeds)
             self.state.uplight_color = target_color
-            self.state.uplight_is_on = True
-            self.state.downlight_is_on = False  # downlight zones were zeroed
             self.state.stored_uplight_color = target_color
             self.state.last_uplight_color = target_color
             self.state.downlight_colors = list(tile_colors[self.downlight_zones])
@@ -624,6 +625,10 @@ class CeilingLight(MatrixLight):
 
             # Turn on with the requested duration - light fades on to target color
             await super().set_power(True, duration)
+
+            # Mark is_on flags only after power-on succeeds
+            self.state.uplight_is_on = True
+            self.state.downlight_is_on = False  # downlight zones were zeroed
 
             # Persist AFTER device operations complete
             if self._state_file:
@@ -768,9 +773,8 @@ class CeilingLight(MatrixLight):
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
             # Update state — public fields, stored state, and last-known
+            # (is_on flags deferred until after power-on succeeds)
             self.state.downlight_colors = list(target_colors)
-            self.state.downlight_is_on = True
-            self.state.uplight_is_on = False  # uplight zone was zeroed
             self.state.stored_downlight_colors = list(target_colors)
             self.state.last_downlight_colors = list(target_colors)
             self.state.uplight_color = tile_colors[self.uplight_zone]
@@ -778,6 +782,10 @@ class CeilingLight(MatrixLight):
 
             # Turn on with the requested duration - light fades on to target colors
             await super().set_power(True, duration)
+
+            # Mark is_on flags only after power-on succeeds
+            self.state.downlight_is_on = True
+            self.state.uplight_is_on = False  # uplight zone was zeroed
 
             # Persist AFTER device operations complete
             if self._state_file:
@@ -850,7 +858,9 @@ class CeilingLight(MatrixLight):
             state.stored_uplight_color = tile_colors[self.uplight_zone]
             state.stored_downlight_colors = list(tile_colors[self.downlight_zones])
 
-            # Update last-known and mark components as off (power is being turned off)
+            # Sync public fields, last-known, and mark components as off
+            state.uplight_color = state.stored_uplight_color
+            state.downlight_colors = list(state.stored_downlight_colors)
             state.last_uplight_color = state.stored_uplight_color
             state.last_downlight_colors = list(state.stored_downlight_colors)
             state.uplight_is_on = False
@@ -911,7 +921,7 @@ class CeilingLight(MatrixLight):
 
         # Update all state fields — all zones now have the same color
         state = self.state
-        is_on = color.brightness > 0
+        is_on = bool(state.power > 0 and color.brightness > 0)
         downlight_colors = [color] * self.downlight_zone_count
         state.uplight_color = color
         state.downlight_colors = list(downlight_colors)

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -1092,7 +1092,7 @@ class CeilingLight(MatrixLight):
         state = self.state
         if state.stored_downlight_colors is not None:
             if any(c.brightness > 0 for c in state.stored_downlight_colors):
-                return state.stored_downlight_colors
+                return list(state.stored_downlight_colors)
 
         # Get current colors (use pre-fetched if available)
         if tile_colors is None:

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
@@ -47,6 +47,14 @@ class CeilingLightState(MatrixLightState):
         downlight_is_on: Whether downlight component is on (any zone brightness > 0)
         uplight_zone: Zone index for the uplight component
         downlight_zones: Slice representing downlight component zones
+        stored_uplight_color: Stored uplight color for restoration
+            after turning off
+        stored_downlight_colors: Stored downlight colors for restoration
+            after turning off
+        last_uplight_color: Last known uplight color, updated after
+            every operation
+        last_downlight_colors: Last known downlight colors, updated
+            after every operation
     """
 
     uplight_color: HSBK
@@ -55,6 +63,10 @@ class CeilingLightState(MatrixLightState):
     downlight_is_on: bool
     uplight_zone: int
     downlight_zones: slice
+    stored_uplight_color: HSBK | None = field(default=None)
+    stored_downlight_colors: list[HSBK] | None = field(default=None)
+    last_uplight_color: HSBK | None = field(default=None)
+    last_downlight_colors: list[HSBK] | None = field(default=None)
 
     @property
     def as_dict(self) -> Any:
@@ -69,6 +81,9 @@ class CeilingLightState(MatrixLightState):
         downlight_colors: list[HSBK],
         uplight_zone: int,
         downlight_zones: slice,
+        *,
+        stored_uplight_color: HSBK | None = None,
+        stored_downlight_colors: list[HSBK] | None = None,
     ) -> CeilingLightState:
         """Create CeilingLightState from MatrixLightState.
 
@@ -78,9 +93,13 @@ class CeilingLightState(MatrixLightState):
             downlight_colors: Current downlight zone colors
             uplight_zone: Zone index for uplight component
             downlight_zones: Slice representing downlight component zones
+            stored_uplight_color: Stored uplight color for restoration
+            stored_downlight_colors: Stored downlight colors for
+                restoration
 
         Returns:
-            CeilingLightState with all matrix state plus ceiling components
+            CeilingLightState with all matrix state plus ceiling
+            components
         """
         return cls(
             model=matrix_state.model,
@@ -105,6 +124,10 @@ class CeilingLightState(MatrixLightState):
             downlight_is_on=any(c.brightness > 0 for c in downlight_colors),
             uplight_zone=uplight_zone,
             downlight_zones=downlight_zones,
+            stored_uplight_color=stored_uplight_color,
+            stored_downlight_colors=stored_downlight_colors,
+            last_uplight_color=uplight_color,
+            last_downlight_colors=downlight_colors,
             last_updated=time.time(),
         )
 
@@ -163,10 +186,6 @@ class CeilingLight(MatrixLight):
         """
         super().__init__(serial, ip, port, timeout, max_retries)
         self._state_file = state_file
-        self._stored_uplight_state: HSBK | None = None
-        self._stored_downlight_state: list[HSBK] | None = None
-        self._last_uplight_color: HSBK | None = None
-        self._last_downlight_colors: list[HSBK] | None = None
 
     async def __aenter__(self) -> CeilingLight:
         """Async context manager entry."""
@@ -206,11 +225,9 @@ class CeilingLight(MatrixLight):
         uplight_color = tile_colors[self.uplight_zone]
         downlight_colors = list(tile_colors[self.downlight_zones])
 
-        # Cache for is_on properties
-        self._last_uplight_color = uplight_color
-        self._last_downlight_colors = downlight_colors
-
         # Create ceiling state from matrix state
+        # (from_matrix_state sets last_uplight_color and
+        # last_downlight_colors automatically)
         ceiling_state = CeilingLightState.from_matrix_state(
             matrix_state=matrix_state,
             uplight_color=uplight_color,
@@ -219,7 +236,7 @@ class CeilingLight(MatrixLight):
             downlight_zones=self.downlight_zones,
         )
 
-        # Store in _state - cast is used in state property to access ceiling fields
+        # Store in _state - cast is used in state property
         self._state = ceiling_state
 
         return ceiling_state
@@ -242,19 +259,15 @@ class CeilingLight(MatrixLight):
         uplight_color = tile_colors[self.uplight_zone]
         downlight_colors = list(tile_colors[self.downlight_zones])
 
-        # Cache for is_on properties
-        self._last_uplight_color = uplight_color
-        self._last_downlight_colors = downlight_colors
-
         # Update ceiling-specific state fields
         state = cast(CeilingLightState, self._state)
         state.uplight_color = uplight_color
         state.downlight_colors = downlight_colors
-        state.uplight_is_on = bool(
-            self.state.power > 0 and uplight_color.brightness > 0
-        )
+        state.last_uplight_color = uplight_color
+        state.last_downlight_colors = downlight_colors
+        state.uplight_is_on = bool(state.power > 0 and uplight_color.brightness > 0)
         state.downlight_is_on = bool(
-            self.state.power > 0 and any(c.brightness > 0 for c in downlight_colors)
+            state.power > 0 and any(c.brightness > 0 for c in downlight_colors)
         )
 
     @classmethod
@@ -369,8 +382,9 @@ class CeilingLight(MatrixLight):
         Calculated as: power_level > 0 AND uplight brightness > 0
 
         Note:
-            Requires recent data from device. Call get_uplight_color() or
-            get_power() to refresh cached values before checking this property.
+            Requires recent data from device. Call get_uplight_color()
+            or get_power() to refresh cached values before checking
+            this property.
 
         Returns:
             True if uplight component is on, False otherwise
@@ -378,20 +392,23 @@ class CeilingLight(MatrixLight):
         if self._state is None or self._state.power == 0:
             return False
 
-        if self._last_uplight_color is None:
+        state = cast(CeilingLightState, self._state)
+        if state.last_uplight_color is None:
             return False
 
-        return self._last_uplight_color.brightness > 0
+        return state.last_uplight_color.brightness > 0
 
     @property
     def downlight_is_on(self) -> bool:
         """True if downlight component is currently on.
 
-        Calculated as: power_level > 0 AND NOT all downlight zones have brightness == 0
+        Calculated as: power_level > 0 AND NOT all downlight zones
+        have brightness == 0
 
         Note:
-            Requires recent data from device. Call get_downlight_colors() or
-            get_power() to refresh cached values before checking this property.
+            Requires recent data from device. Call
+            get_downlight_colors() or get_power() to refresh cached
+            values before checking this property.
 
         Returns:
             True if downlight component is on, False otherwise
@@ -399,11 +416,11 @@ class CeilingLight(MatrixLight):
         if self._state is None or self._state.power == 0:
             return False
 
-        if self._last_downlight_colors is None:
+        state = cast(CeilingLightState, self._state)
+        if state.last_downlight_colors is None:
             return False
 
-        # Downlight is on if any downlight zone has a brightness > 0
-        return any(c.brightness > 0 for c in self._last_downlight_colors)
+        return any(c.brightness > 0 for c in state.last_downlight_colors)
 
     async def get_uplight_color(self) -> HSBK:
         """Get current uplight component color from device.
@@ -421,8 +438,8 @@ class CeilingLight(MatrixLight):
         # Extract uplight zone
         uplight_color = tile_colors[self.uplight_zone]
 
-        # Cache for is_on property
-        self._last_uplight_color = uplight_color
+        # Update state cache
+        self.state.last_uplight_color = uplight_color
 
         return uplight_color
 
@@ -442,8 +459,8 @@ class CeilingLight(MatrixLight):
         # Extract downlight zones
         downlight_colors = tile_colors[self.downlight_zones]
 
-        # Cache for is_on property
-        self._last_downlight_colors = downlight_colors
+        # Update state cache
+        self.state.last_downlight_colors = downlight_colors
 
         return downlight_colors
 
@@ -478,8 +495,8 @@ class CeilingLight(MatrixLight):
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
         # Store state
-        self._stored_uplight_state = color
-        self._last_uplight_color = color
+        self.state.stored_uplight_color = color
+        self.state.last_uplight_color = color
 
         # Persist if enabled
         if self._state_file:
@@ -537,8 +554,8 @@ class CeilingLight(MatrixLight):
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
         # Store state
-        self._stored_downlight_state = downlight_colors
-        self._last_downlight_colors = downlight_colors
+        self.state.stored_downlight_colors = downlight_colors
+        self.state.last_downlight_colors = downlight_colors
 
         # Persist if enabled
         if self._state_file:
@@ -583,7 +600,7 @@ class CeilingLight(MatrixLight):
             # Store current downlight colors BEFORE zeroing them out
             # This allows turn_downlight_on() to restore them later
             downlight_colors = tile_colors[self.downlight_zones]
-            self._stored_downlight_state = list(downlight_colors)
+            self.state.stored_downlight_colors = list(downlight_colors)
 
             # Set uplight zone to target color
             tile_colors[self.uplight_zone] = target_color
@@ -601,8 +618,8 @@ class CeilingLight(MatrixLight):
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
             # Update stored state for uplight
-            self._stored_uplight_state = target_color
-            self._last_uplight_color = target_color
+            self.state.stored_uplight_color = target_color
+            self.state.last_uplight_color = target_color
 
             # Turn on with the requested duration - light fades on to target color
             await super().set_power(True, duration)
@@ -653,10 +670,10 @@ class CeilingLight(MatrixLight):
             stored_color = color
         else:
             stored_color = tile_colors[self.uplight_zone]
-            self._last_uplight_color = stored_color
+            self.state.last_uplight_color = stored_color
 
         # Store for future restoration
-        self._stored_uplight_state = stored_color
+        self.state.stored_uplight_color = stored_color
 
         # Create color with brightness=0 for device
         off_color = HSBK(
@@ -671,7 +688,7 @@ class CeilingLight(MatrixLight):
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
         # Update cache
-        self._last_uplight_color = off_color
+        self.state.last_uplight_color = off_color
 
         # Persist if enabled
         if self._state_file:
@@ -730,7 +747,7 @@ class CeilingLight(MatrixLight):
 
             # Store current uplight color BEFORE zeroing it out
             # This allows turn_uplight_on() to restore it later
-            self._stored_uplight_state = tile_colors[self.uplight_zone]
+            self.state.stored_uplight_color = tile_colors[self.uplight_zone]
 
             # Set downlight zones to target colors
             tile_colors[self.downlight_zones] = target_colors
@@ -748,8 +765,8 @@ class CeilingLight(MatrixLight):
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
             # Update stored state for downlight
-            self._stored_downlight_state = target_colors
-            self._last_downlight_colors = target_colors
+            self.state.stored_downlight_colors = target_colors
+            self.state.last_downlight_colors = target_colors
 
             # Turn on with the requested duration - light fades on to target colors
             await super().set_power(True, duration)
@@ -821,12 +838,13 @@ class CeilingLight(MatrixLight):
             tile_colors = all_colors[0]
 
             # Extract and store both component colors
-            self._stored_uplight_state = tile_colors[self.uplight_zone]
-            self._stored_downlight_state = list(tile_colors[self.downlight_zones])
+            state = self.state
+            state.stored_uplight_color = tile_colors[self.uplight_zone]
+            state.stored_downlight_colors = list(tile_colors[self.downlight_zones])
 
             # Also update cache for is_on properties
-            self._last_uplight_color = self._stored_uplight_state
-            self._last_downlight_colors = self._stored_downlight_state
+            state.last_uplight_color = state.stored_uplight_color
+            state.last_downlight_colors = state.stored_downlight_colors
 
         # Call parent to perform actual power change
         await super().set_power(level, duration)
@@ -872,12 +890,13 @@ class CeilingLight(MatrixLight):
         await super().set_color(color, duration)
 
         # Update cached component colors - all zones now have the same color
-        self._last_uplight_color = color
-        self._last_downlight_colors = [color] * self.downlight_zone_count
+        state = self.state
+        state.last_uplight_color = color
+        state.last_downlight_colors = [color] * self.downlight_zone_count
 
         # Also update stored state for restoration
-        self._stored_uplight_state = color
-        self._stored_downlight_state = [color] * self.downlight_zone_count
+        state.stored_uplight_color = color
+        state.stored_downlight_colors = [color] * self.downlight_zone_count
 
         # Persist if enabled
         if self._state_file:
@@ -934,10 +953,10 @@ class CeilingLight(MatrixLight):
         # If colors not provided, extract from fetched data
         if stored_colors is None:
             stored_colors = list(tile_colors[self.downlight_zones])
-            self._last_downlight_colors = stored_colors
+            self.state.last_downlight_colors = stored_colors
 
         # Store for future restoration
-        self._stored_downlight_state = stored_colors
+        self.state.stored_downlight_colors = stored_colors
 
         # Create colors with brightness=0 for device
         off_colors = [
@@ -955,7 +974,7 @@ class CeilingLight(MatrixLight):
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
         # Update cache
-        self._last_downlight_colors = off_colors
+        self.state.last_downlight_colors = off_colors
 
         # Persist if enabled
         if self._state_file:
@@ -979,11 +998,12 @@ class CeilingLight(MatrixLight):
             HSBK color for uplight
         """
         # 1. Stored state (only if brightness > 0)
+        state = self.state
         if (
-            self._stored_uplight_state is not None
-            and self._stored_uplight_state.brightness > 0
+            state.stored_uplight_color is not None
+            and state.stored_uplight_color.brightness > 0
         ):
-            return self._stored_uplight_state
+            return state.stored_uplight_color
 
         # Get current colors (use pre-fetched if available)
         if tile_colors is None:
@@ -993,12 +1013,12 @@ class CeilingLight(MatrixLight):
         current_uplight = tile_colors[self.uplight_zone]
         downlight_colors = tile_colors[self.downlight_zones]
 
-        # Cache for is_on properties
-        self._last_uplight_color = current_uplight
-        self._last_downlight_colors = list(downlight_colors)
+        # Update state cache
+        state.last_uplight_color = current_uplight
+        state.last_downlight_colors = list(downlight_colors)
 
         # Determine which color source to use for H, S, K
-        source_color = self._stored_uplight_state or current_uplight
+        source_color = state.stored_uplight_color or current_uplight
 
         # 2. Infer from downlight average brightness
         avg_brightness = sum(c.brightness for c in downlight_colors) / len(
@@ -1041,9 +1061,10 @@ class CeilingLight(MatrixLight):
             List of HSBK colors for downlight zones
         """
         # 1. Stored state (only if any color has brightness > 0)
-        if self._stored_downlight_state is not None:
-            if any(c.brightness > 0 for c in self._stored_downlight_state):
-                return self._stored_downlight_state
+        state = self.state
+        if state.stored_downlight_colors is not None:
+            if any(c.brightness > 0 for c in state.stored_downlight_colors):
+                return state.stored_downlight_colors
 
         # Get current colors (use pre-fetched if available)
         if tile_colors is None:
@@ -1053,14 +1074,14 @@ class CeilingLight(MatrixLight):
         current_downlight = list(tile_colors[self.downlight_zones])
         uplight_color = tile_colors[self.uplight_zone]
 
-        # Cache for is_on properties
-        self._last_downlight_colors = current_downlight
-        self._last_uplight_color = uplight_color
+        # Update state cache
+        state.last_downlight_colors = current_downlight
+        state.last_uplight_color = uplight_color
 
         # Prefer stored H, S, K if available, otherwise use current
         source_colors: list[HSBK] = (
-            self._stored_downlight_state
-            if self._stored_downlight_state is not None
+            state.stored_downlight_colors
+            if state.stored_downlight_colors is not None
             else current_downlight
         )
 
@@ -1101,11 +1122,12 @@ class CeilingLight(MatrixLight):
         Returns:
             True if stored state matches current (H, S, K), False otherwise
         """
+        state = self.state
         if component == "uplight":
-            if self._stored_uplight_state is None or not isinstance(current, HSBK):
+            if state.stored_uplight_color is None or not isinstance(current, HSBK):
                 return False
 
-            stored = self._stored_uplight_state
+            stored = state.stored_uplight_color
             return (
                 stored.hue == current.hue
                 and stored.saturation == current.saturation
@@ -1113,16 +1135,16 @@ class CeilingLight(MatrixLight):
             )
 
         if component == "downlight":
-            if self._stored_downlight_state is None or not isinstance(current, list):
+            if state.stored_downlight_colors is None or not isinstance(current, list):
                 return False
 
-            if len(self._stored_downlight_state) != len(current):
+            if len(state.stored_downlight_colors) != len(current):
                 return False
 
             # Check if all zones match (H, S, K)
             return all(
                 s.hue == c.hue and s.saturation == c.saturation and s.kelvin == c.kelvin
-                for s, c in zip(self._stored_downlight_state, current)
+                for s, c in zip(state.stored_downlight_colors, current)
             )
 
         return False
@@ -1151,9 +1173,10 @@ class CeilingLight(MatrixLight):
                 return
 
             # Load uplight state
+            state = self.state
             if "uplight" in device_state:
                 uplight_data = device_state["uplight"]
-                self._stored_uplight_state = HSBK(
+                state.stored_uplight_color = HSBK(
                     hue=uplight_data["hue"],
                     saturation=uplight_data["saturation"],
                     brightness=uplight_data["brightness"],
@@ -1163,7 +1186,7 @@ class CeilingLight(MatrixLight):
             # Load downlight state
             if "downlight" in device_state:
                 downlight_data = device_state["downlight"]
-                self._stored_downlight_state = [
+                state.stored_downlight_colors = [
                     HSBK(
                         hue=c["hue"],
                         saturation=c["saturation"],
@@ -1198,16 +1221,17 @@ class CeilingLight(MatrixLight):
 
             # Update state for this device
             device_state = {}
+            state = self.state
 
-            if self._stored_uplight_state:
+            if state.stored_uplight_color:
                 device_state["uplight"] = {
-                    "hue": self._stored_uplight_state.hue,
-                    "saturation": self._stored_uplight_state.saturation,
-                    "brightness": self._stored_uplight_state.brightness,
-                    "kelvin": self._stored_uplight_state.kelvin,
+                    "hue": state.stored_uplight_color.hue,
+                    "saturation": state.stored_uplight_color.saturation,
+                    "brightness": state.stored_uplight_color.brightness,
+                    "kelvin": state.stored_uplight_color.kelvin,
                 }
 
-            if self._stored_downlight_state:
+            if state.stored_downlight_colors:
                 device_state["downlight"] = [
                     {
                         "hue": c.hue,
@@ -1215,7 +1239,7 @@ class CeilingLight(MatrixLight):
                         "brightness": c.brightness,
                         "kelvin": c.kelvin,
                     }
-                    for c in self._stored_downlight_state
+                    for c in state.stored_downlight_colors
                 ]
 
             data[self.serial] = device_state

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -382,9 +382,8 @@ class CeilingLight(MatrixLight):
         Calculated as: power_level > 0 AND uplight brightness > 0
 
         Note:
-            Requires recent data from device. Call get_uplight_color()
-            or get_power() to refresh cached values before checking
-            this property.
+            Requires recent data from device. Call refresh_state()
+            to update cached values before checking this property.
 
         Returns:
             True if uplight component is on, False otherwise
@@ -406,9 +405,8 @@ class CeilingLight(MatrixLight):
         have brightness == 0
 
         Note:
-            Requires recent data from device. Call
-            get_downlight_colors() or get_power() to refresh cached
-            values before checking this property.
+            Requires recent data from device. Call refresh_state()
+            to update cached values before checking this property.
 
         Returns:
             True if downlight component is on, False otherwise
@@ -1088,11 +1086,14 @@ class CeilingLight(MatrixLight):
         Returns:
             List of HSBK colors for downlight zones
         """
-        # 1. Stored state (only if any color has brightness > 0)
+        # 1. Stored state (only if correct length and any brightness > 0)
         state = self.state
-        if state.stored_downlight_colors is not None:
-            if any(c.brightness > 0 for c in state.stored_downlight_colors):
-                return list(state.stored_downlight_colors)
+        if (
+            state.stored_downlight_colors is not None
+            and len(state.stored_downlight_colors) == self.downlight_zone_count
+            and any(c.brightness > 0 for c in state.stored_downlight_colors)
+        ):
+            return list(state.stored_downlight_colors)
 
         # Get current colors (use pre-fetched if available)
         if tile_colors is None:
@@ -1106,10 +1107,11 @@ class CeilingLight(MatrixLight):
         state.last_downlight_colors = current_downlight
         state.last_uplight_color = uplight_color
 
-        # Prefer stored H, S, K if available, otherwise use current
+        # Prefer stored H, S, K if available and correct length, otherwise use current
         source_colors: list[HSBK] = (
             state.stored_downlight_colors
             if state.stored_downlight_colors is not None
+            and len(state.stored_downlight_colors) == self.downlight_zone_count
             else current_downlight
         )
 
@@ -1211,10 +1213,10 @@ class CeilingLight(MatrixLight):
                     kelvin=uplight_data["kelvin"],
                 )
 
-            # Load downlight state
+            # Load downlight state (validate zone count if version is available)
             if "downlight" in device_state:
                 downlight_data = device_state["downlight"]
-                state.stored_downlight_colors = [
+                loaded_colors = [
                     HSBK(
                         hue=c["hue"],
                         saturation=c["saturation"],
@@ -1223,6 +1225,21 @@ class CeilingLight(MatrixLight):
                     )
                     for c in downlight_data
                 ]
+                try:
+                    expected = self.downlight_zone_count
+                except LifxError:
+                    # Version not yet available — accept loaded data
+                    state.stored_downlight_colors = loaded_colors
+                else:
+                    if len(loaded_colors) == expected:
+                        state.stored_downlight_colors = loaded_colors
+                    else:
+                        _LOGGER.warning(
+                            "Ignoring stored downlight state:"
+                            " expected %d zones, got %d",
+                            expected,
+                            len(loaded_colors),
+                        )
 
             _LOGGER.debug("Loaded state from %s for device %s", state_path, self.serial)
 

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -120,8 +120,9 @@ class CeilingLightState(MatrixLightState):
             effect=matrix_state.effect,
             uplight_color=uplight_color,
             downlight_colors=downlight_colors,
-            uplight_is_on=uplight_color.brightness > 0,
-            downlight_is_on=any(c.brightness > 0 for c in downlight_colors),
+            uplight_is_on=matrix_state.power > 0 and uplight_color.brightness > 0,
+            downlight_is_on=matrix_state.power > 0
+            and any(c.brightness > 0 for c in downlight_colors),
             uplight_zone=uplight_zone,
             downlight_zones=downlight_zones,
             stored_uplight_color=stored_uplight_color,
@@ -858,16 +859,20 @@ class CeilingLight(MatrixLight):
             state.stored_uplight_color = tile_colors[self.uplight_zone]
             state.stored_downlight_colors = list(tile_colors[self.downlight_zones])
 
-            # Sync public fields, last-known, and mark components as off
+            # Sync public fields and last-known colours
             state.uplight_color = state.stored_uplight_color
             state.downlight_colors = list(state.stored_downlight_colors)
             state.last_uplight_color = state.stored_uplight_color
             state.last_downlight_colors = list(state.stored_downlight_colors)
-            state.uplight_is_on = False
-            state.downlight_is_on = False
 
         # Call parent to perform actual power change
         await super().set_power(level, duration)
+
+        # Mark components as off only after power-off succeeds
+        if turning_off:
+            state = self.state
+            state.uplight_is_on = False
+            state.downlight_is_on = False
 
         # When turning on, recompute booleans from last-known colours
         if not turning_off:

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -440,6 +440,9 @@ class CeilingLight(MatrixLight):
 
         # Update state cache
         self.state.last_uplight_color = uplight_color
+        self.state.uplight_is_on = bool(
+            self._state.power > 0 and uplight_color.brightness > 0
+        )
 
         return uplight_color
 
@@ -461,6 +464,9 @@ class CeilingLight(MatrixLight):
 
         # Update state cache
         self.state.last_downlight_colors = downlight_colors
+        self.state.downlight_is_on = bool(
+            self._state.power > 0 and any(c.brightness > 0 for c in downlight_colors)
+        )
 
         return downlight_colors
 

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -127,7 +127,7 @@ class CeilingLightState(MatrixLightState):
             stored_uplight_color=stored_uplight_color,
             stored_downlight_colors=stored_downlight_colors,
             last_uplight_color=uplight_color,
-            last_downlight_colors=downlight_colors,
+            last_downlight_colors=list(downlight_colors),
             last_updated=time.time(),
         )
 
@@ -262,9 +262,9 @@ class CeilingLight(MatrixLight):
         # Update ceiling-specific state fields
         state = cast(CeilingLightState, self._state)
         state.uplight_color = uplight_color
-        state.downlight_colors = downlight_colors
+        state.downlight_colors = list(downlight_colors)
         state.last_uplight_color = uplight_color
-        state.last_downlight_colors = downlight_colors
+        state.last_downlight_colors = list(downlight_colors)
         state.uplight_is_on = bool(state.power > 0 and uplight_color.brightness > 0)
         state.downlight_is_on = bool(
             state.power > 0 and any(c.brightness > 0 for c in downlight_colors)
@@ -438,10 +438,6 @@ class CeilingLight(MatrixLight):
         # Extract uplight zone
         uplight_color = tile_colors[self.uplight_zone]
 
-        # Update state cache (don't update uplight_is_on — power may be stale)
-        self.state.uplight_color = uplight_color
-        self.state.last_uplight_color = uplight_color
-
         return uplight_color
 
     async def get_downlight_colors(self) -> list[HSBK]:
@@ -460,11 +456,7 @@ class CeilingLight(MatrixLight):
         # Extract downlight zones
         downlight_colors = tile_colors[self.downlight_zones]
 
-        # Update state cache (don't update downlight_is_on — power may be stale)
-        self.state.downlight_colors = list(downlight_colors)
-        self.state.last_downlight_colors = downlight_colors
-
-        return downlight_colors
+        return list(downlight_colors)
 
     async def set_uplight_color(self, color: HSBK, duration: float = 0.0) -> None:
         """Set uplight component color.
@@ -558,10 +550,10 @@ class CeilingLight(MatrixLight):
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
         # Update state — public fields, stored state, and last-known
-        self.state.downlight_colors = downlight_colors
+        self.state.downlight_colors = list(downlight_colors)
         self.state.downlight_is_on = True  # brightness > 0 validated above
-        self.state.stored_downlight_colors = downlight_colors
-        self.state.last_downlight_colors = downlight_colors
+        self.state.stored_downlight_colors = list(downlight_colors)
+        self.state.last_downlight_colors = list(downlight_colors)
 
         # Persist if enabled
         if self._state_file:
@@ -629,6 +621,8 @@ class CeilingLight(MatrixLight):
             self.state.downlight_is_on = False  # downlight zones were zeroed
             self.state.stored_uplight_color = target_color
             self.state.last_uplight_color = target_color
+            self.state.downlight_colors = list(tile_colors[self.downlight_zones])
+            self.state.last_downlight_colors = list(tile_colors[self.downlight_zones])
 
             # Turn on with the requested duration - light fades on to target color
             await super().set_power(True, duration)
@@ -776,11 +770,13 @@ class CeilingLight(MatrixLight):
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
             # Update state — public fields, stored state, and last-known
-            self.state.downlight_colors = target_colors
+            self.state.downlight_colors = list(target_colors)
             self.state.downlight_is_on = True
             self.state.uplight_is_on = False  # uplight zone was zeroed
-            self.state.stored_downlight_colors = target_colors
-            self.state.last_downlight_colors = target_colors
+            self.state.stored_downlight_colors = list(target_colors)
+            self.state.last_downlight_colors = list(target_colors)
+            self.state.uplight_color = tile_colors[self.uplight_zone]
+            self.state.last_uplight_color = tile_colors[self.uplight_zone]
 
             # Turn on with the requested duration - light fades on to target colors
             await super().set_power(True, duration)
@@ -858,12 +854,22 @@ class CeilingLight(MatrixLight):
 
             # Update last-known and mark components as off (power is being turned off)
             state.last_uplight_color = state.stored_uplight_color
-            state.last_downlight_colors = state.stored_downlight_colors
+            state.last_downlight_colors = list(state.stored_downlight_colors)
             state.uplight_is_on = False
             state.downlight_is_on = False
 
         # Call parent to perform actual power change
         await super().set_power(level, duration)
+
+        # When turning on, recompute booleans from last-known colours
+        if not turning_off:
+            state = self.state
+            if state.last_uplight_color is not None:
+                state.uplight_is_on = state.last_uplight_color.brightness > 0
+            if state.last_downlight_colors is not None:
+                state.downlight_is_on = any(
+                    c.brightness > 0 for c in state.last_downlight_colors
+                )
 
         # Persist AFTER device operation completes
         if turning_off and self._state_file:
@@ -910,13 +916,13 @@ class CeilingLight(MatrixLight):
         is_on = color.brightness > 0
         downlight_colors = [color] * self.downlight_zone_count
         state.uplight_color = color
-        state.downlight_colors = downlight_colors
+        state.downlight_colors = list(downlight_colors)
         state.uplight_is_on = is_on
         state.downlight_is_on = is_on
         state.last_uplight_color = color
-        state.last_downlight_colors = downlight_colors
+        state.last_downlight_colors = list(downlight_colors)
         state.stored_uplight_color = color
-        state.stored_downlight_colors = downlight_colors
+        state.stored_downlight_colors = list(downlight_colors)
 
         # Persist if enabled
         if self._state_file:
@@ -973,10 +979,10 @@ class CeilingLight(MatrixLight):
         # If colors not provided, extract from fetched data
         if stored_colors is None:
             stored_colors = list(tile_colors[self.downlight_zones])
-            self.state.last_downlight_colors = stored_colors
+            self.state.last_downlight_colors = list(stored_colors)
 
         # Store for future restoration
-        self.state.stored_downlight_colors = stored_colors
+        self.state.stored_downlight_colors = list(stored_colors)
 
         # Create colors with brightness=0 for device
         off_colors = [
@@ -994,7 +1000,9 @@ class CeilingLight(MatrixLight):
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
         # Update cache
-        self.state.last_downlight_colors = off_colors
+        self.state.downlight_colors = list(off_colors)
+        self.state.downlight_is_on = False
+        self.state.last_downlight_colors = list(off_colors)
 
         # Persist if enabled
         if self._state_file:

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -672,15 +672,11 @@ class CeilingLight(MatrixLight):
         all_colors = await self.get_all_tile_colors()
         tile_colors = all_colors[0]
 
-        # Determine which color to store
+        # Determine which color to store (kept local until I/O succeeds)
         if color is not None:
             stored_color = color
         else:
             stored_color = tile_colors[self.uplight_zone]
-            self.state.last_uplight_color = stored_color
-
-        # Store for future restoration
-        self.state.stored_uplight_color = stored_color
 
         # Create color with brightness=0 for device
         off_color = HSBK(
@@ -694,7 +690,8 @@ class CeilingLight(MatrixLight):
         tile_colors[self.uplight_zone] = off_color
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
-        # Update state — public fields and last-known
+        # Update state only after I/O succeeds
+        self.state.stored_uplight_color = stored_color
         self.state.uplight_color = off_color
         self.state.uplight_is_on = False
         self.state.last_uplight_color = off_color
@@ -989,13 +986,10 @@ class CeilingLight(MatrixLight):
         all_colors = await self.get_all_tile_colors()
         tile_colors = all_colors[0]
 
-        # If colors not provided, extract from fetched data
+        # If not provided, extract from fetched data
+        # (kept local until I/O succeeds)
         if stored_colors is None:
             stored_colors = list(tile_colors[self.downlight_zones])
-            self.state.last_downlight_colors = list(stored_colors)
-
-        # Store for future restoration
-        self.state.stored_downlight_colors = list(stored_colors)
 
         # Create colors with brightness=0 for device
         off_colors = [
@@ -1012,7 +1006,8 @@ class CeilingLight(MatrixLight):
         tile_colors[self.downlight_zones] = off_colors
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
-        # Update cache
+        # Update state only after I/O succeeds
+        self.state.stored_downlight_colors = list(stored_colors)
         self.state.downlight_colors = list(off_colors)
         self.state.downlight_is_on = False
         self.state.last_downlight_colors = list(off_colors)

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -438,11 +438,9 @@ class CeilingLight(MatrixLight):
         # Extract uplight zone
         uplight_color = tile_colors[self.uplight_zone]
 
-        # Update state cache
+        # Update state cache (don't update uplight_is_on — power may be stale)
+        self.state.uplight_color = uplight_color
         self.state.last_uplight_color = uplight_color
-        self.state.uplight_is_on = bool(
-            self._state.power > 0 and uplight_color.brightness > 0
-        )
 
         return uplight_color
 
@@ -462,11 +460,9 @@ class CeilingLight(MatrixLight):
         # Extract downlight zones
         downlight_colors = tile_colors[self.downlight_zones]
 
-        # Update state cache
+        # Update state cache (don't update downlight_is_on — power may be stale)
+        self.state.downlight_colors = list(downlight_colors)
         self.state.last_downlight_colors = downlight_colors
-        self.state.downlight_is_on = bool(
-            self._state.power > 0 and any(c.brightness > 0 for c in downlight_colors)
-        )
 
         return downlight_colors
 
@@ -500,7 +496,9 @@ class CeilingLight(MatrixLight):
         # Set all colors back (duration in milliseconds for set_matrix_colors)
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
-        # Store state
+        # Update state — public fields, stored state, and last-known
+        self.state.uplight_color = color
+        self.state.uplight_is_on = True  # brightness > 0 validated above
         self.state.stored_uplight_color = color
         self.state.last_uplight_color = color
 
@@ -559,7 +557,9 @@ class CeilingLight(MatrixLight):
         # Set all colors back
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
-        # Store state
+        # Update state — public fields, stored state, and last-known
+        self.state.downlight_colors = downlight_colors
+        self.state.downlight_is_on = True  # brightness > 0 validated above
         self.state.stored_downlight_colors = downlight_colors
         self.state.last_downlight_colors = downlight_colors
 
@@ -623,7 +623,10 @@ class CeilingLight(MatrixLight):
             # Set all colors instantly (duration=0) while light is off
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
-            # Update stored state for uplight
+            # Update state — public fields, stored state, and last-known
+            self.state.uplight_color = target_color
+            self.state.uplight_is_on = True
+            self.state.downlight_is_on = False  # downlight zones were zeroed
             self.state.stored_uplight_color = target_color
             self.state.last_uplight_color = target_color
 
@@ -693,7 +696,9 @@ class CeilingLight(MatrixLight):
         tile_colors[self.uplight_zone] = off_color
         await self.set_matrix_colors(0, tile_colors, duration=int(duration * 1000))
 
-        # Update cache
+        # Update state — public fields and last-known
+        self.state.uplight_color = off_color
+        self.state.uplight_is_on = False
         self.state.last_uplight_color = off_color
 
         # Persist if enabled
@@ -770,7 +775,10 @@ class CeilingLight(MatrixLight):
             # Set all colors instantly (duration=0) while light is off
             await self.set_matrix_colors(0, tile_colors, duration=0)
 
-            # Update stored state for downlight
+            # Update state — public fields, stored state, and last-known
+            self.state.downlight_colors = target_colors
+            self.state.downlight_is_on = True
+            self.state.uplight_is_on = False  # uplight zone was zeroed
             self.state.stored_downlight_colors = target_colors
             self.state.last_downlight_colors = target_colors
 
@@ -848,9 +856,11 @@ class CeilingLight(MatrixLight):
             state.stored_uplight_color = tile_colors[self.uplight_zone]
             state.stored_downlight_colors = list(tile_colors[self.downlight_zones])
 
-            # Also update cache for is_on properties
+            # Update last-known and mark components as off (power is being turned off)
             state.last_uplight_color = state.stored_uplight_color
             state.last_downlight_colors = state.stored_downlight_colors
+            state.uplight_is_on = False
+            state.downlight_is_on = False
 
         # Call parent to perform actual power change
         await super().set_power(level, duration)
@@ -895,14 +905,18 @@ class CeilingLight(MatrixLight):
         # Call parent to perform actual color change
         await super().set_color(color, duration)
 
-        # Update cached component colors - all zones now have the same color
+        # Update all state fields — all zones now have the same color
         state = self.state
+        is_on = color.brightness > 0
+        downlight_colors = [color] * self.downlight_zone_count
+        state.uplight_color = color
+        state.downlight_colors = downlight_colors
+        state.uplight_is_on = is_on
+        state.downlight_is_on = is_on
         state.last_uplight_color = color
-        state.last_downlight_colors = [color] * self.downlight_zone_count
-
-        # Also update stored state for restoration
+        state.last_downlight_colors = downlight_colors
         state.stored_uplight_color = color
-        state.stored_downlight_colors = [color] * self.downlight_zone_count
+        state.stored_downlight_colors = downlight_colors
 
         # Persist if enabled
         if self._state_file:

--- a/tests/test_devices/test_ceiling.py
+++ b/tests/test_devices/test_ceiling.py
@@ -2676,3 +2676,41 @@ class TestCeilingLightStateCoverage:
             assert ceiling.state.stored_uplight_color is None
             assert ceiling.state.stored_downlight_colors is not None
             assert len(ceiling.state.stored_downlight_colors) == 1
+
+    def test_load_state_ignores_wrong_zone_count(self) -> None:
+        """Test _load_state_from_file ignores downlight with wrong zone count."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / "state.json"
+            # Product 176 expects 63 downlight zones, provide only 10
+            state_data = {
+                "d073d5010203": {
+                    "downlight": [
+                        {
+                            "hue": 0.0,
+                            "saturation": 0.0,
+                            "brightness": 1.0,
+                            "kelvin": 3500,
+                        }
+                        for _ in range(10)
+                    ],
+                }
+            }
+            with state_file.open("w") as f:
+                json.dump(state_data, f)
+
+            ceiling = CeilingLight(
+                serial="d073d5010203",
+                ip="192.168.1.100",
+                state_file=str(state_file),
+            )
+            ceiling._state = _make_mock_state()
+            ceiling._version = MagicMock()
+            ceiling._version.product = 176
+
+            ceiling._load_state_from_file()
+
+            # Downlight should be rejected due to zone count mismatch
+            assert ceiling.state.stored_downlight_colors is None

--- a/tests/test_devices/test_ceiling.py
+++ b/tests/test_devices/test_ceiling.py
@@ -2290,3 +2290,389 @@ class TestCeilingLightTurnOnPowerBehavior:
         assert sent_colors[63].hue == 60
         assert sent_colors[63].saturation == 0.5
         assert sent_colors[63].kelvin == 4000
+
+
+class TestCeilingLightStateCoverage:
+    """Additional tests for uncovered branches in CeilingLight."""
+
+    @pytest.fixture
+    def ceiling_176(self) -> CeilingLight:
+        """Create a Ceiling product 176 (8x8) instance with mocked connection."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
+        ceiling.set_matrix_colors = AsyncMock()
+        ceiling._save_state_to_file = MagicMock()
+
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        default_tile_colors = [white] * 64
+        ceiling.get_all_tile_colors = AsyncMock(return_value=[default_tile_colors])
+
+        ceiling._version = MagicMock()
+        ceiling._version.product = 176
+        return ceiling
+
+    def test_as_dict_property(self) -> None:
+        """Test CeilingLightState.as_dict returns a dict via dataclasses.asdict."""
+        from lifx.devices.ceiling import CeilingLightState
+
+        state = MagicMock(spec=CeilingLightState)
+        mock_dict = {"key": "value"}
+        with patch(
+            "lifx.devices.ceiling.asdict", return_value=mock_dict
+        ) as mock_asdict:
+            # Call the real property implementation
+            result = CeilingLightState.as_dict.fget(state)  # type: ignore[union-attr]
+            mock_asdict.assert_called_once_with(state)
+        assert result == mock_dict
+
+    def test_state_property_raises_when_uninitialised(self) -> None:
+        """Test state property raises RuntimeError when _state is None."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling._state = None
+        with pytest.raises(RuntimeError, match="State not found"):
+            _ = ceiling.state
+
+    def test_downlight_zone_count_raises_on_invalid_config(self) -> None:
+        """Test downlight_zone_count raises LifxError when stop is None."""
+        ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling._state = _make_mock_state()
+        ceiling._version = MagicMock()
+        ceiling._version.product = 176
+        # Monkey-patch downlight_zones to return slice with stop=None
+        none_slice = property(lambda self: slice(0, None))
+        with patch.object(
+            type(ceiling), "downlight_zones", new_callable=lambda: none_slice
+        ):
+            with pytest.raises(LifxError, match="Invalid downlight zones"):
+                _ = ceiling.downlight_zone_count
+
+    async def test_refresh_state_updates_component_fields(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test refresh_state updates ceiling-specific fields from tile_colors."""
+        uplight_color = HSBK(hue=120, saturation=0.8, brightness=0.6, kelvin=4000)
+        downlight_colors = [
+            HSBK(hue=i * 5, saturation=0.5, brightness=0.9, kelvin=3500)
+            for i in range(63)
+        ]
+        tile_colors = downlight_colors + [uplight_color]
+
+        # Use a MagicMock state with tile_colors list that supports slicing
+        state = _make_mock_state(power=65535)
+        state.tile_colors = tile_colors
+        ceiling_176._state = state
+
+        with patch.object(MatrixLight, "refresh_state", new_callable=AsyncMock):
+            await ceiling_176.refresh_state()
+
+        assert state.uplight_color == uplight_color
+        assert len(state.downlight_colors) == 63
+        assert state.last_uplight_color == uplight_color
+        assert state.last_downlight_colors == downlight_colors
+        assert state.uplight_is_on is True
+        assert state.downlight_is_on is True
+
+    async def test_refresh_state_power_off(self, ceiling_176: CeilingLight) -> None:
+        """Test refresh_state marks components off when power is 0."""
+        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
+        tile_colors = [white] * 63 + [white]
+
+        state = _make_mock_state(power=0)
+        state.tile_colors = tile_colors
+        ceiling_176._state = state
+
+        with patch.object(MatrixLight, "refresh_state", new_callable=AsyncMock):
+            await ceiling_176.refresh_state()
+
+        assert state.uplight_is_on is False
+        assert state.downlight_is_on is False
+
+    async def test_turn_uplight_on_persists_state_file_when_light_off(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_uplight_on saves state to file when light is off."""
+        ceiling_176._state_file = "/tmp/test_state.json"
+        ceiling_176.get_power = AsyncMock(return_value=0)
+        color = HSBK(hue=120, saturation=1.0, brightness=0.8, kelvin=3500)
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.turn_uplight_on(color, duration=1.0)
+
+        ceiling_176._save_state_to_file.assert_called_once()
+
+    async def test_turn_downlight_on_persists_state_file_when_light_off(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_downlight_on saves state to file when light is off."""
+        ceiling_176._state_file = "/tmp/test_state.json"
+        ceiling_176.get_power = AsyncMock(return_value=0)
+        color = HSBK(hue=240, saturation=1.0, brightness=0.8, kelvin=3500)
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.turn_downlight_on(color, duration=1.0)
+
+        ceiling_176._save_state_to_file.assert_called_once()
+
+    async def test_turn_downlight_on_list_all_zero_brightness_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_downlight_on raises when list of colours all have brightness=0."""
+        colors = [HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500)] * 63
+        with pytest.raises(ValueError, match="brightness"):
+            await ceiling_176.turn_downlight_on(colors)
+
+    async def test_turn_downlight_on_list_wrong_length_raises(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_downlight_on raises when list length doesn't match zone count."""
+        colors = [HSBK(hue=0, saturation=0, brightness=1.0, kelvin=3500)] * 10
+        with pytest.raises(ValueError, match="Expected 63 colors"):
+            await ceiling_176.turn_downlight_on(colors)
+
+    async def test_turn_downlight_on_list_colors_when_light_off(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test turn_downlight_on with list of colours when light is off."""
+        ceiling_176.get_power = AsyncMock(return_value=0)
+        colors = [
+            HSBK(hue=i * 5, saturation=1.0, brightness=0.8, kelvin=3500)
+            for i in range(63)
+        ]
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.turn_downlight_on(colors, duration=1.0)
+
+        ceiling_176.set_matrix_colors.assert_called_once()
+        call_args = ceiling_176.set_matrix_colors.call_args
+        sent_colors = call_args[0][1]
+        # Downlight zones should have the provided colours
+        for i in range(63):
+            assert sent_colors[i].brightness == pytest.approx(0.8, abs=0.01)
+
+    async def test_set_power_on_recomputes_component_booleans(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test set_power(True) recomputes uplight_is_on/downlight_is_on."""
+        # Set last-known colours with specific brightness values
+        ceiling_176.state.last_uplight_color = HSBK(
+            hue=120, saturation=0.5, brightness=0.7, kelvin=3500
+        )
+        ceiling_176.state.last_downlight_colors = [
+            HSBK(hue=0, saturation=0.0, brightness=0.9, kelvin=3500)
+        ] * 63
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.set_power(True)
+
+        assert ceiling_176.state.uplight_is_on is True
+        assert ceiling_176.state.downlight_is_on is True
+
+    async def test_set_power_on_recomputes_booleans_zero_brightness(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test set_power(True) sets booleans False when brightness is 0."""
+        ceiling_176.state.last_uplight_color = HSBK(
+            hue=120, saturation=0.5, brightness=0.0, kelvin=3500
+        )
+        ceiling_176.state.last_downlight_colors = [
+            HSBK(hue=0, saturation=0.0, brightness=0.0, kelvin=3500)
+        ] * 63
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.set_power(True)
+
+        assert ceiling_176.state.uplight_is_on is False
+        assert ceiling_176.state.downlight_is_on is False
+
+    async def test_determine_uplight_brightness_fetches_when_no_tile_colors(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test _determine_uplight_brightness fetches tile_colors when not passed."""
+        ceiling_176.state.stored_uplight_color = None
+
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.0, kelvin=2700)
+        downlight_colors = [
+            HSBK(hue=0, saturation=0.0, brightness=0.8, kelvin=3500)
+        ] * 63
+        ceiling_176.get_all_tile_colors = AsyncMock(
+            return_value=[downlight_colors + [uplight_color]]
+        )
+
+        # Call without tile_colors argument (triggers fetch)
+        result = await ceiling_176._determine_uplight_brightness()
+
+        ceiling_176.get_all_tile_colors.assert_called_once()
+        assert result.brightness > 0
+
+    async def test_determine_uplight_brightness_with_prefetched_tile_colors(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test _determine_uplight_brightness skips fetch when tile_colors passed."""
+        ceiling_176.state.stored_uplight_color = None
+
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.0, kelvin=2700)
+        downlight_colors = [
+            HSBK(hue=0, saturation=0.0, brightness=0.8, kelvin=3500)
+        ] * 63
+        tile_colors = downlight_colors + [uplight_color]
+
+        # Call with pre-fetched tile_colors (skips fetch)
+        result = await ceiling_176._determine_uplight_brightness(tile_colors)
+
+        ceiling_176.get_all_tile_colors.assert_not_called()
+        assert result.brightness > 0
+
+    async def test_determine_downlight_brightness_fetches_when_no_tile_colors(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test _determine_downlight_brightness fetches tile_colors when not passed."""
+        ceiling_176.state.stored_downlight_colors = None
+
+        downlight_colors = [
+            HSBK(hue=i * 5, saturation=0.8, brightness=0.0, kelvin=3500)
+            for i in range(63)
+        ]
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.8, kelvin=2700)
+        ceiling_176.get_all_tile_colors = AsyncMock(
+            return_value=[downlight_colors + [uplight_color]]
+        )
+
+        # Call without tile_colors argument (triggers fetch)
+        result = await ceiling_176._determine_downlight_brightness()
+
+        ceiling_176.get_all_tile_colors.assert_called_once()
+        assert len(result) == 63
+
+    async def test_determine_downlight_brightness_with_prefetched_tile_colors(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test _determine_downlight_brightness skips fetch when tile_colors passed."""
+        ceiling_176.state.stored_downlight_colors = None
+
+        downlight_colors = [
+            HSBK(hue=i * 5, saturation=0.8, brightness=0.0, kelvin=3500)
+            for i in range(63)
+        ]
+        uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.8, kelvin=2700)
+        tile_colors = downlight_colors + [uplight_color]
+
+        # Call with pre-fetched tile_colors (skips fetch)
+        result = await ceiling_176._determine_downlight_brightness(tile_colors)
+
+        ceiling_176.get_all_tile_colors.assert_not_called()
+        assert len(result) == 63
+
+    def test_load_state_from_file_with_downlight_data(self) -> None:
+        """Test _load_state_from_file loads both uplight and downlight data."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / "state.json"
+            state_data = {
+                "d073d5010203": {
+                    "uplight": {
+                        "hue": 120.0,
+                        "saturation": 0.8,
+                        "brightness": 0.6,
+                        "kelvin": 4000,
+                    },
+                    "downlight": [
+                        {
+                            "hue": float(i * 5),
+                            "saturation": 0.5,
+                            "brightness": 0.9,
+                            "kelvin": 3500,
+                        }
+                        for i in range(63)
+                    ],
+                }
+            }
+            with state_file.open("w") as f:
+                json.dump(state_data, f)
+
+            ceiling = CeilingLight(
+                serial="d073d5010203",
+                ip="192.168.1.100",
+                state_file=str(state_file),
+            )
+            ceiling._state = _make_mock_state()
+
+            ceiling._load_state_from_file()
+
+            assert ceiling.state.stored_uplight_color is not None
+            assert ceiling.state.stored_uplight_color.hue == pytest.approx(120.0)
+            assert ceiling.state.stored_downlight_colors is not None
+            assert len(ceiling.state.stored_downlight_colors) == 63
+            assert ceiling.state.stored_downlight_colors[0].saturation == pytest.approx(
+                0.5
+            )
+
+    def test_load_state_from_file_uplight_only(self) -> None:
+        """Test _load_state_from_file with uplight data but no downlight."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / "state.json"
+            state_data = {
+                "d073d5010203": {
+                    "uplight": {
+                        "hue": 60.0,
+                        "saturation": 0.3,
+                        "brightness": 0.9,
+                        "kelvin": 3000,
+                    },
+                }
+            }
+            with state_file.open("w") as f:
+                json.dump(state_data, f)
+
+            ceiling = CeilingLight(
+                serial="d073d5010203",
+                ip="192.168.1.100",
+                state_file=str(state_file),
+            )
+            ceiling._state = _make_mock_state()
+
+            ceiling._load_state_from_file()
+
+            assert ceiling.state.stored_uplight_color is not None
+            assert ceiling.state.stored_uplight_color.hue == pytest.approx(60.0)
+            assert ceiling.state.stored_downlight_colors is None
+
+    def test_load_state_from_file_downlight_only(self) -> None:
+        """Test _load_state_from_file with downlight data but no uplight."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / "state.json"
+            state_data = {
+                "d073d5010203": {
+                    "downlight": [
+                        {
+                            "hue": 0.0,
+                            "saturation": 0.0,
+                            "brightness": 1.0,
+                            "kelvin": 3500,
+                        }
+                    ],
+                }
+            }
+            with state_file.open("w") as f:
+                json.dump(state_data, f)
+
+            ceiling = CeilingLight(
+                serial="d073d5010203",
+                ip="192.168.1.100",
+                state_file=str(state_file),
+            )
+            ceiling._state = _make_mock_state()
+
+            ceiling._load_state_from_file()
+
+            assert ceiling.state.stored_uplight_color is None
+            assert ceiling.state.stored_downlight_colors is not None
+            assert len(ceiling.state.stored_downlight_colors) == 1

--- a/tests/test_devices/test_ceiling.py
+++ b/tests/test_devices/test_ceiling.py
@@ -16,6 +16,17 @@ from lifx.exceptions import LifxError
 from lifx.products import get_ceiling_layout
 
 
+def _make_mock_state(power: int = 65535) -> MagicMock:
+    """Create a mock CeilingLightState with correct defaults."""
+    state = MagicMock()
+    state.power = power
+    state.stored_uplight_color = None
+    state.stored_downlight_colors = None
+    state.last_uplight_color = None
+    state.last_downlight_colors = None
+    return state
+
+
 class TestCeilingLightComponentDetection:
     """Tests for component detection and configuration."""
 
@@ -115,6 +126,7 @@ class TestCeilingLightGetMethods:
         """Create a Ceiling product 176 (8x8) instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         # Mock version for product detection
         ceiling._version = MagicMock()
         ceiling._version.product = 176
@@ -166,6 +178,7 @@ class TestCeilingLightSetMethods:
         """Create a Ceiling product 176 (8x8) instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -196,7 +209,7 @@ class TestCeilingLightSetMethods:
         assert call_args.kwargs.get("duration") == 1000  # duration in milliseconds
 
         # Verify stored state was updated
-        assert ceiling_176._stored_uplight_state == color
+        assert ceiling_176.state.stored_uplight_color == color
 
     async def test_set_uplight_color_zero_brightness_raises(
         self, ceiling_176: CeilingLight
@@ -226,8 +239,8 @@ class TestCeilingLightSetMethods:
         assert call_args.kwargs.get("duration") == 500  # duration in milliseconds
 
         # Verify stored state was updated
-        assert len(ceiling_176._stored_downlight_state) == 63
-        assert all(c == color for c in ceiling_176._stored_downlight_state)
+        assert len(ceiling_176.state.stored_downlight_colors) == 63
+        assert all(c == color for c in ceiling_176.state.stored_downlight_colors)
 
     async def test_set_downlight_colors_list_hsbk(
         self, ceiling_176: CeilingLight
@@ -251,7 +264,7 @@ class TestCeilingLightSetMethods:
         assert call_args.args[1][0:63] == colors
 
         # Verify stored state was updated
-        assert ceiling_176._stored_downlight_state == colors
+        assert ceiling_176.state.stored_downlight_colors == colors
 
     async def test_set_downlight_colors_invalid_length_raises(
         self, ceiling_176: CeilingLight
@@ -299,6 +312,7 @@ class TestCeilingLightTurnOnOff:
         """Create a Ceiling product 176 (8x8) instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -322,14 +336,14 @@ class TestCeilingLightTurnOnOff:
         # Verify set_matrix_colors was called
         ceiling_176.set_matrix_colors.assert_called_once()
         # Verify stored state was updated
-        assert ceiling_176._stored_uplight_state == color
+        assert ceiling_176.state.stored_uplight_color == color
 
     async def test_turn_uplight_on_without_color_uses_stored(
         self, ceiling_176: CeilingLight
     ) -> None:
         """Test turning uplight on without color uses stored state."""
         stored_color = HSBK(hue=60, saturation=0.5, brightness=0.7, kelvin=4000)
-        ceiling_176._stored_uplight_state = stored_color
+        ceiling_176.state.stored_uplight_color = stored_color
 
         await ceiling_176.turn_uplight_on()
 
@@ -345,7 +359,7 @@ class TestCeilingLightTurnOnOff:
     ) -> None:
         """Test turning uplight on infers brightness from downlight average."""
         # No stored state
-        ceiling_176._stored_uplight_state = None
+        ceiling_176.state.stored_uplight_color = None
 
         # Mock downlight colors with average brightness 0.6
         downlight_colors = [
@@ -373,7 +387,7 @@ class TestCeilingLightTurnOnOff:
     ) -> None:
         """Test turn uplight on uses default brightness when no stored state."""
         # No stored state
-        ceiling_176._stored_uplight_state = None
+        ceiling_176.state.stored_uplight_color = None
 
         # Mock current uplight color (off) and downlight colors (all off too)
         uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.0, kelvin=2700)
@@ -405,8 +419,8 @@ class TestCeilingLightTurnOnOff:
         await ceiling_176.turn_uplight_off()
 
         # Should store current color (with brightness preserved)
-        assert ceiling_176._stored_uplight_state is not None
-        assert ceiling_176._stored_uplight_state.brightness == pytest.approx(
+        assert ceiling_176.state.stored_uplight_color is not None
+        assert ceiling_176.state.stored_uplight_color.brightness == pytest.approx(
             0.5, abs=0.01
         )
 
@@ -426,7 +440,7 @@ class TestCeilingLightTurnOnOff:
         await ceiling_176.turn_uplight_off(provided_color)
 
         # Should store provided color
-        assert ceiling_176._stored_uplight_state == provided_color
+        assert ceiling_176.state.stored_uplight_color == provided_color
 
         # Should set device to brightness=0 (with provided H, S, K)
         ceiling_176.set_matrix_colors.assert_called_once()
@@ -481,7 +495,7 @@ class TestCeilingLightTurnOnOff:
             HSBK(hue=i * 5, saturation=1.0, brightness=0.7, kelvin=3500)
             for i in range(63)
         ]
-        ceiling_176._stored_downlight_state = stored_colors
+        ceiling_176.state.stored_downlight_colors = stored_colors
 
         await ceiling_176.turn_downlight_on()
 
@@ -497,7 +511,7 @@ class TestCeilingLightTurnOnOff:
     ) -> None:
         """Test turning downlight on infers brightness from uplight."""
         # No stored state
-        ceiling_176._stored_downlight_state = None
+        ceiling_176.state.stored_downlight_colors = None
 
         # Mock uplight with brightness 0.5
         uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
@@ -542,11 +556,11 @@ class TestCeilingLightTurnOnOff:
         await ceiling_176.turn_downlight_off()
 
         # Should store current colors (with brightness preserved)
-        assert ceiling_176._stored_downlight_state is not None
-        assert len(ceiling_176._stored_downlight_state) == 63
+        assert ceiling_176.state.stored_downlight_colors is not None
+        assert len(ceiling_176.state.stored_downlight_colors) == 63
         assert all(
             c.brightness == pytest.approx(0.8, abs=0.01)
-            for c in ceiling_176._stored_downlight_state
+            for c in ceiling_176.state.stored_downlight_colors
         )
 
         # Should set device to brightness=0
@@ -566,9 +580,11 @@ class TestCeilingLightTurnOnOff:
         await ceiling_176.turn_downlight_off(provided_color)
 
         # Should store provided color for all zones
-        assert ceiling_176._stored_downlight_state is not None
-        assert len(ceiling_176._stored_downlight_state) == 63
-        assert all(c == provided_color for c in ceiling_176._stored_downlight_state)
+        assert ceiling_176.state.stored_downlight_colors is not None
+        assert len(ceiling_176.state.stored_downlight_colors) == 63
+        assert all(
+            c == provided_color for c in ceiling_176.state.stored_downlight_colors
+        )
 
         # Should set device to brightness=0
         ceiling_176.set_matrix_colors.assert_called_once()
@@ -611,9 +627,7 @@ class TestCeilingLightProperties:
         """Create a Ceiling product 176 (8x8) instance."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
-        # Mock cached power state
-        ceiling._state = MagicMock()
-        ceiling._state.power = 65535  # Power on
+        ceiling._state = _make_mock_state()
         # Mock version for product detection
         ceiling._version = MagicMock()
         ceiling._version.product = 176
@@ -622,7 +636,7 @@ class TestCeilingLightProperties:
     def test_uplight_is_on_when_on(self, ceiling_176: CeilingLight) -> None:
         """Test uplight_is_on returns True when uplight is on."""
         # Set cached uplight color with brightness > 0
-        ceiling_176._last_uplight_color = HSBK(
+        ceiling_176.state.last_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.5, kelvin=2700
         )
 
@@ -631,7 +645,7 @@ class TestCeilingLightProperties:
     def test_uplight_is_on_when_off(self, ceiling_176: CeilingLight) -> None:
         """Test uplight_is_on returns False when uplight is off."""
         # Set cached uplight color with brightness = 0
-        ceiling_176._last_uplight_color = HSBK(
+        ceiling_176.state.last_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.0, kelvin=2700
         )
 
@@ -640,7 +654,7 @@ class TestCeilingLightProperties:
     def test_uplight_is_on_when_power_off(self, ceiling_176: CeilingLight) -> None:
         """Test uplight_is_on returns False when device power is off."""
         ceiling_176._state.power = 0  # Power off
-        ceiling_176._last_uplight_color = HSBK(
+        ceiling_176.state.last_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.5, kelvin=2700
         )
 
@@ -648,14 +662,14 @@ class TestCeilingLightProperties:
 
     def test_uplight_is_on_when_no_cached_data(self, ceiling_176: CeilingLight) -> None:
         """Test uplight_is_on returns False when no cached data."""
-        ceiling_176._last_uplight_color = None
+        ceiling_176.state.last_uplight_color = None
 
         assert ceiling_176.uplight_is_on is False
 
     def test_downlight_is_on_when_on(self, ceiling_176: CeilingLight) -> None:
         """Test downlight_is_on returns True when any downlight zone is on."""
         # Set some zones with brightness > 0
-        ceiling_176._last_downlight_colors = [
+        ceiling_176.state.last_downlight_colors = [
             HSBK(hue=0, saturation=0, brightness=0.0 if i < 10 else 1.0, kelvin=3500)
             for i in range(63)
         ]
@@ -665,7 +679,7 @@ class TestCeilingLightProperties:
     def test_downlight_is_on_when_all_off(self, ceiling_176: CeilingLight) -> None:
         """Test downlight_is_on returns False when all zones are off."""
         # All zones with brightness = 0
-        ceiling_176._last_downlight_colors = [
+        ceiling_176.state.last_downlight_colors = [
             HSBK(hue=0, saturation=0, brightness=0.0, kelvin=3500) for _ in range(63)
         ]
 
@@ -675,7 +689,7 @@ class TestCeilingLightProperties:
         """Test downlight_is_on returns False when device power is off."""
         ceiling_176._state.power = 0  # Power off
         white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
-        ceiling_176._last_downlight_colors = [white] * 63
+        ceiling_176.state.last_downlight_colors = [white] * 63
 
         assert ceiling_176.downlight_is_on is False
 
@@ -683,7 +697,7 @@ class TestCeilingLightProperties:
         self, ceiling_176: CeilingLight
     ) -> None:
         """Test downlight_is_on returns False when no cached data."""
-        ceiling_176._last_downlight_colors = None
+        ceiling_176.state.last_downlight_colors = None
 
         assert ceiling_176.downlight_is_on is False
 
@@ -702,6 +716,7 @@ class TestCeilingLightStatePersistence:
                 state_file=str(state_file),
             )
             ceiling.connection = AsyncMock()
+            ceiling._state = _make_mock_state()
             ceiling.set_matrix_colors = AsyncMock()
             ceiling.get_all_tile_colors = AsyncMock()
 
@@ -714,11 +729,11 @@ class TestCeilingLightStatePersistence:
         """Test state file is created when saving state."""
         # Set some state
         uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
-        ceiling_176._stored_uplight_state = uplight_color
+        ceiling_176.state.stored_uplight_color = uplight_color
 
         white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
         downlight_colors = [white] * 63
-        ceiling_176._stored_downlight_state = downlight_colors
+        ceiling_176.state.stored_downlight_colors = downlight_colors
 
         # Save to file
         ceiling_176._save_state_to_file()
@@ -759,17 +774,17 @@ class TestCeilingLightStatePersistence:
         ceiling_176._load_state_from_file()
 
         # Verify loaded state
-        assert ceiling_176._stored_uplight_state is not None
-        assert ceiling_176._stored_uplight_state.hue == pytest.approx(30, abs=1)
-        assert ceiling_176._stored_uplight_state.brightness == pytest.approx(
+        assert ceiling_176.state.stored_uplight_color is not None
+        assert ceiling_176.state.stored_uplight_color.hue == pytest.approx(30, abs=1)
+        assert ceiling_176.state.stored_uplight_color.brightness == pytest.approx(
             0.5, abs=0.01
         )
 
-        assert ceiling_176._stored_downlight_state is not None
-        assert len(ceiling_176._stored_downlight_state) == 63
+        assert ceiling_176.state.stored_downlight_colors is not None
+        assert len(ceiling_176.state.stored_downlight_colors) == 63
         assert all(
             c.brightness == pytest.approx(1.0, abs=0.01)
-            for c in ceiling_176._stored_downlight_state
+            for c in ceiling_176.state.stored_downlight_colors
         )
 
     async def test_state_persistence_across_operations(
@@ -789,12 +804,13 @@ class TestCeilingLightStatePersistence:
             ip="192.168.1.100",
             state_file=ceiling_176._state_file,
         )
+        ceiling_new._state = _make_mock_state()
         ceiling_new._load_state_from_file()
 
         # Verify state was loaded
-        assert ceiling_new._stored_uplight_state is not None
-        assert ceiling_new._stored_uplight_state.hue == pytest.approx(60, abs=1)
-        assert ceiling_new._stored_uplight_state.brightness == pytest.approx(
+        assert ceiling_new.state.stored_uplight_color is not None
+        assert ceiling_new.state.stored_uplight_color.hue == pytest.approx(60, abs=1)
+        assert ceiling_new.state.stored_uplight_color.brightness == pytest.approx(
             0.7, abs=0.01
         )
 
@@ -807,6 +823,7 @@ class TestCeilingLightBackwardCompatibility:
         """Create a Ceiling product 176 instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling._save_state_to_file = MagicMock()
 
         # Mock version for product detection
@@ -826,12 +843,12 @@ class TestCeilingLightBackwardCompatibility:
         assert ceiling_176.connection.request.called
 
         # Verify uplight state was updated
-        assert ceiling_176._last_uplight_color == color
-        assert ceiling_176._stored_uplight_state == color
+        assert ceiling_176.state.last_uplight_color == color
+        assert ceiling_176.state.stored_uplight_color == color
 
         # Verify downlight state was updated (63 zones for product 176)
-        assert ceiling_176._last_downlight_colors == [color] * 63
-        assert ceiling_176._stored_downlight_state == [color] * 63
+        assert ceiling_176.state.last_downlight_colors == [color] * 63
+        assert ceiling_176.state.stored_downlight_colors == [color] * 63
 
         # Verify state was NOT persisted (no state_file configured)
         ceiling_176._save_state_to_file.assert_not_called()
@@ -1118,9 +1135,6 @@ class TestCeilingLightErrorHandling:
         """Test uplight_is_on returns False when _state is None."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling._state = None
-        ceiling._last_uplight_color = HSBK(
-            hue=30, saturation=0.2, brightness=0.5, kelvin=2700
-        )
 
         assert ceiling.uplight_is_on is False
 
@@ -1128,8 +1142,6 @@ class TestCeilingLightErrorHandling:
         """Test downlight_is_on returns False when _state is None."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling._state = None
-        white = HSBK(hue=0, saturation=0.0, brightness=1.0, kelvin=3500)
-        ceiling._last_downlight_colors = [white] * 63
 
         assert ceiling.downlight_is_on is False
 
@@ -1141,13 +1153,14 @@ class TestCeilingLightIsStoredStateValid:
     def ceiling_176(self) -> CeilingLight:
         """Create a Ceiling product 176 instance."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling._state = _make_mock_state()
         ceiling._version = MagicMock()
         ceiling._version.product = 176
         return ceiling
 
     def test_uplight_valid_match(self, ceiling_176: CeilingLight) -> None:
         """Test uplight stored state matches current (ignoring brightness)."""
-        ceiling_176._stored_uplight_state = HSBK(
+        ceiling_176.state.stored_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.8, kelvin=2700
         )
         current = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
@@ -1156,14 +1169,14 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_uplight_no_stored_state(self, ceiling_176: CeilingLight) -> None:
         """Test uplight returns False when no stored state."""
-        ceiling_176._stored_uplight_state = None
+        ceiling_176.state.stored_uplight_color = None
         current = HSBK(hue=30, saturation=0.2, brightness=0.5, kelvin=2700)
 
         assert ceiling_176._is_stored_state_valid("uplight", current) is False
 
     def test_uplight_wrong_type(self, ceiling_176: CeilingLight) -> None:
         """Test uplight returns False when current is not HSBK."""
-        ceiling_176._stored_uplight_state = HSBK(
+        ceiling_176.state.stored_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.8, kelvin=2700
         )
         # Pass a list instead of HSBK
@@ -1173,7 +1186,7 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_uplight_hue_mismatch(self, ceiling_176: CeilingLight) -> None:
         """Test uplight returns False when hue doesn't match."""
-        ceiling_176._stored_uplight_state = HSBK(
+        ceiling_176.state.stored_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.8, kelvin=2700
         )
         current = HSBK(hue=60, saturation=0.2, brightness=0.5, kelvin=2700)
@@ -1182,7 +1195,7 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_downlight_valid_match(self, ceiling_176: CeilingLight) -> None:
         """Test downlight stored state matches current (ignoring brightness)."""
-        ceiling_176._stored_downlight_state = [
+        ceiling_176.state.stored_downlight_colors = [
             HSBK(hue=i * 5, saturation=0.8, brightness=0.9, kelvin=3500)
             for i in range(63)
         ]
@@ -1195,7 +1208,7 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_downlight_no_stored_state(self, ceiling_176: CeilingLight) -> None:
         """Test downlight returns False when no stored state."""
-        ceiling_176._stored_downlight_state = None
+        ceiling_176.state.stored_downlight_colors = None
         current = [
             HSBK(hue=0, saturation=0, brightness=1.0, kelvin=3500) for _ in range(63)
         ]
@@ -1204,7 +1217,7 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_downlight_wrong_type(self, ceiling_176: CeilingLight) -> None:
         """Test downlight returns False when current is not list."""
-        ceiling_176._stored_downlight_state = [
+        ceiling_176.state.stored_downlight_colors = [
             HSBK(hue=0, saturation=0, brightness=0.9, kelvin=3500) for _ in range(63)
         ]
         # Pass HSBK instead of list
@@ -1214,7 +1227,7 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_downlight_length_mismatch(self, ceiling_176: CeilingLight) -> None:
         """Test downlight returns False when lengths don't match."""
-        ceiling_176._stored_downlight_state = [
+        ceiling_176.state.stored_downlight_colors = [
             HSBK(hue=0, saturation=0, brightness=0.9, kelvin=3500) for _ in range(63)
         ]
         current = [
@@ -1226,7 +1239,7 @@ class TestCeilingLightIsStoredStateValid:
 
     def test_downlight_saturation_mismatch(self, ceiling_176: CeilingLight) -> None:
         """Test downlight returns False when saturation doesn't match."""
-        ceiling_176._stored_downlight_state = [
+        ceiling_176.state.stored_downlight_colors = [
             HSBK(hue=0, saturation=0.8, brightness=0.9, kelvin=3500) for _ in range(63)
         ]
         current = [
@@ -1251,12 +1264,13 @@ class TestCeilingLightStateFileEdgeCases:
     def test_load_state_no_state_file(self) -> None:
         """Test _load_state_from_file does nothing when no state file."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling._state = _make_mock_state()
         ceiling._state_file = None
 
         # Should not raise
         ceiling._load_state_from_file()
-        assert ceiling._stored_uplight_state is None
-        assert ceiling._stored_downlight_state is None
+        assert ceiling.state.stored_uplight_color is None
+        assert ceiling.state.stored_downlight_colors is None
 
     def test_load_state_file_not_exists(self) -> None:
         """Test _load_state_from_file handles non-existent file."""
@@ -1266,10 +1280,11 @@ class TestCeilingLightStateFileEdgeCases:
                 ip="192.168.1.100",
                 state_file=str(Path(tmpdir) / "nonexistent.json"),
             )
+            ceiling._state = _make_mock_state()
 
             # Should not raise
             ceiling._load_state_from_file()
-            assert ceiling._stored_uplight_state is None
+            assert ceiling.state.stored_uplight_color is None
 
     def test_load_state_no_device_state(self) -> None:
         """Test _load_state_from_file handles file without device state."""
@@ -1284,9 +1299,10 @@ class TestCeilingLightStateFileEdgeCases:
                 ip="192.168.1.100",
                 state_file=str(state_file),
             )
+            ceiling._state = _make_mock_state()
 
             ceiling._load_state_from_file()
-            assert ceiling._stored_uplight_state is None
+            assert ceiling.state.stored_uplight_color is None
 
     def test_load_state_invalid_json(self) -> None:
         """Test _load_state_from_file handles invalid JSON gracefully."""
@@ -1300,16 +1316,18 @@ class TestCeilingLightStateFileEdgeCases:
                 ip="192.168.1.100",
                 state_file=str(state_file),
             )
+            ceiling._state = _make_mock_state()
 
             # Should not raise, just log warning
             ceiling._load_state_from_file()
-            assert ceiling._stored_uplight_state is None
+            assert ceiling.state.stored_uplight_color is None
 
     def test_save_state_no_state_file(self) -> None:
         """Test _save_state_to_file does nothing when no state file."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
+        ceiling._state = _make_mock_state()
         ceiling._state_file = None
-        ceiling._stored_uplight_state = HSBK(
+        ceiling.state.stored_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.5, kelvin=2700
         )
 
@@ -1325,7 +1343,8 @@ class TestCeilingLightStateFileEdgeCases:
                 ip="192.168.1.100",
                 state_file=str(state_file),
             )
-            ceiling._stored_uplight_state = HSBK(
+            ceiling._state = _make_mock_state()
+            ceiling.state.stored_uplight_color = HSBK(
                 hue=30, saturation=0.2, brightness=0.5, kelvin=2700
             )
 
@@ -1361,7 +1380,8 @@ class TestCeilingLightStateFileEdgeCases:
                 ip="192.168.1.100",
                 state_file=str(state_file),
             )
-            ceiling._stored_uplight_state = HSBK(
+            ceiling._state = _make_mock_state()
+            ceiling.state.stored_uplight_color = HSBK(
                 hue=30, saturation=0.2, brightness=0.5, kelvin=2700
             )
 
@@ -1381,7 +1401,8 @@ class TestCeilingLightStateFileEdgeCases:
             ip="192.168.1.100",
             state_file="/nonexistent/path/that/cannot/be/created/state.json",
         )
-        ceiling._stored_uplight_state = HSBK(
+        ceiling._state = _make_mock_state()
+        ceiling.state.stored_uplight_color = HSBK(
             hue=30, saturation=0.2, brightness=0.5, kelvin=2700
         )
 
@@ -1397,6 +1418,7 @@ class TestCeilingLightTurnDownlightOffWithList:
         """Create a Ceiling product 176 instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -1421,9 +1443,9 @@ class TestCeilingLightTurnDownlightOffWithList:
         await ceiling_176.turn_downlight_off(provided_colors)
 
         # Should store provided colors
-        assert ceiling_176._stored_downlight_state is not None
-        assert len(ceiling_176._stored_downlight_state) == 63
-        assert ceiling_176._stored_downlight_state == provided_colors
+        assert ceiling_176.state.stored_downlight_colors is not None
+        assert len(ceiling_176.state.stored_downlight_colors) == 63
+        assert ceiling_176.state.stored_downlight_colors == provided_colors
 
         # Should set device to brightness=0
         ceiling_176.set_matrix_colors.assert_called_once()
@@ -1463,6 +1485,7 @@ class TestCeilingLightBrightnessInference:
         """Create a Ceiling product 176 instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -1474,7 +1497,7 @@ class TestCeilingLightBrightnessInference:
         self, ceiling_176: CeilingLight
     ) -> None:
         """Test _determine_uplight_brightness falls back when downlights are off."""
-        ceiling_176._stored_uplight_state = None
+        ceiling_176.state.stored_uplight_color = None
 
         # All downlights have brightness=0, uplight has target H, S, K
         uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.0, kelvin=2700)
@@ -1499,7 +1522,7 @@ class TestCeilingLightBrightnessInference:
         self, ceiling_176: CeilingLight
     ) -> None:
         """Test _determine_downlight_brightness falls back to default on exception."""
-        ceiling_176._stored_downlight_state = None
+        ceiling_176.state.stored_downlight_colors = None
 
         # Create downlight colors
         downlight_colors = [
@@ -1531,7 +1554,7 @@ class TestCeilingLightBrightnessInference:
         self, ceiling_176: CeilingLight
     ) -> None:
         """Test turn_downlight_on uses default when uplight is off (brightness=0)."""
-        ceiling_176._stored_downlight_state = None
+        ceiling_176.state.stored_downlight_colors = None
 
         # Mock uplight with brightness 0 and downlight with brightness 0
         uplight_color = HSBK(hue=30, saturation=0.2, brightness=0.0, kelvin=2700)
@@ -1632,9 +1655,11 @@ class TestCeilingLightContextManager:
                 await ceiling.__aenter__()
 
                 # Verify state was loaded
-                assert ceiling._stored_uplight_state is not None
-                assert ceiling._stored_uplight_state.hue == pytest.approx(60, abs=1)
-                assert ceiling._stored_uplight_state.brightness == pytest.approx(
+                assert ceiling.state.stored_uplight_color is not None
+                assert ceiling.state.stored_uplight_color.hue == pytest.approx(
+                    60, abs=1
+                )
+                assert ceiling.state.stored_uplight_color.brightness == pytest.approx(
                     0.7, abs=0.01
                 )
             finally:
@@ -1649,6 +1674,7 @@ class TestCeilingLightSetDownlightSingleZeroBrightness:
         """Create a Ceiling product 176 instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -1678,6 +1704,7 @@ class TestCeilingLightSetPowerOverride:
         """Create a Ceiling product 176 instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -1715,8 +1742,8 @@ class TestCeilingLightSetPowerOverride:
             mock_parent.assert_called_once_with(False, 0.0)
 
         # Both colors should be stored (regardless of brightness)
-        assert ceiling_176._stored_uplight_state == uplight_color
-        assert ceiling_176._stored_downlight_state == downlight_off
+        assert ceiling_176.state.stored_uplight_color == uplight_color
+        assert ceiling_176.state.stored_downlight_colors == downlight_off
 
         # State file should NOT be saved (no state_file set in fixture)
         ceiling_176._save_state_to_file.assert_not_called()
@@ -1744,8 +1771,8 @@ class TestCeilingLightSetPowerOverride:
             mock_parent.assert_called_once_with(False, 0.0)
 
         # Both should be stored (regardless of brightness)
-        assert ceiling_176._stored_uplight_state == uplight_off
-        assert ceiling_176._stored_downlight_state == downlight_colors
+        assert ceiling_176.state.stored_uplight_color == uplight_off
+        assert ceiling_176.state.stored_downlight_colors == downlight_colors
 
     async def test_set_power_off_captures_both_components(
         self, ceiling_176: CeilingLight
@@ -1768,8 +1795,8 @@ class TestCeilingLightSetPowerOverride:
             mock_parent.assert_called_once_with(False, 0.0)
 
         # Both should be stored
-        assert ceiling_176._stored_uplight_state == uplight_color
-        assert ceiling_176._stored_downlight_state == downlight_colors
+        assert ceiling_176.state.stored_uplight_color == uplight_color
+        assert ceiling_176.state.stored_downlight_colors == downlight_colors
 
     async def test_set_power_off_with_duration(self, ceiling_176: CeilingLight) -> None:
         """Test set_power(False) passes duration to parent."""
@@ -1791,10 +1818,10 @@ class TestCeilingLightSetPowerOverride:
     ) -> None:
         """Test set_power(True) does NOT capture colors (only off captures)."""
         # Pre-set stored states
-        ceiling_176._stored_uplight_state = HSBK(
+        ceiling_176.state.stored_uplight_color = HSBK(
             hue=100, saturation=0.5, brightness=0.5, kelvin=3500
         )
-        ceiling_176._stored_downlight_state = [
+        ceiling_176.state.stored_downlight_colors = [
             HSBK(hue=200, saturation=0.5, brightness=0.5, kelvin=3500)
         ] * 16
 
@@ -1808,8 +1835,8 @@ class TestCeilingLightSetPowerOverride:
         # (they weren't mocked, so they would fail if called)
 
         # Stored states should remain unchanged
-        assert ceiling_176._stored_uplight_state.hue == 100
-        assert ceiling_176._stored_downlight_state[0].hue == 200
+        assert ceiling_176.state.stored_uplight_color.hue == 100
+        assert ceiling_176.state.stored_downlight_colors[0].hue == 200
 
     async def test_set_power_with_integer_off(self, ceiling_176: CeilingLight) -> None:
         """Test set_power(0) captures colors (integer form)."""
@@ -1830,8 +1857,8 @@ class TestCeilingLightSetPowerOverride:
             mock_parent.assert_called_once_with(0, 0.0)
 
         # Both should be stored regardless of brightness
-        assert ceiling_176._stored_uplight_state == uplight_color
-        assert ceiling_176._stored_downlight_state == downlight_colors
+        assert ceiling_176.state.stored_uplight_color == uplight_color
+        assert ceiling_176.state.stored_downlight_colors == downlight_colors
 
     async def test_set_power_with_integer_on(self, ceiling_176: CeilingLight) -> None:
         """Test set_power(65535) does not capture colors (integer form)."""
@@ -1911,11 +1938,11 @@ class TestCeilingLightSetPowerOverride:
             await ceiling_176.set_power(False)
 
         # Verify uplight was stored
-        assert ceiling_176._stored_uplight_state == uplight_color
+        assert ceiling_176.state.stored_uplight_color == uplight_color
 
         # Now _determine_uplight_brightness should return stored color
         # (simulate what turn_uplight_on() would do)
-        assert ceiling_176._stored_uplight_state.brightness > 0
+        assert ceiling_176.state.stored_uplight_color.brightness > 0
 
 
 class TestCeilingLightTurnOnPowerBehavior:
@@ -1926,6 +1953,7 @@ class TestCeilingLightTurnOnPowerBehavior:
         """Create a Ceiling product 176 (8x8) instance with mocked connection."""
         ceiling = CeilingLight(serial="d073d5010203", ip="192.168.1.100")
         ceiling.connection = AsyncMock()
+        ceiling._state = _make_mock_state()
         ceiling.set_matrix_colors = AsyncMock()
         ceiling._save_state_to_file = MagicMock()
 
@@ -2140,9 +2168,11 @@ class TestCeilingLightTurnOnPowerBehavior:
             await ceiling_176.turn_uplight_on(uplight_color)
 
         # Verify downlight colors were stored
-        assert ceiling_176._stored_downlight_state is not None
-        assert len(ceiling_176._stored_downlight_state) == 63
-        assert all(c == downlight_color for c in ceiling_176._stored_downlight_state)
+        assert ceiling_176.state.stored_downlight_colors is not None
+        assert len(ceiling_176.state.stored_downlight_colors) == 63
+        assert all(
+            c == downlight_color for c in ceiling_176.state.stored_downlight_colors
+        )
 
     async def test_turn_downlight_on_zeros_uplight_when_light_off(
         self, ceiling_176: CeilingLight
@@ -2191,7 +2221,7 @@ class TestCeilingLightTurnOnPowerBehavior:
             await ceiling_176.turn_downlight_on(downlight_color)
 
         # Verify uplight color was stored
-        assert ceiling_176._stored_uplight_state == uplight_color
+        assert ceiling_176.state.stored_uplight_color == uplight_color
 
     async def test_turn_downlight_on_uses_default_brightness_after_uplight_on(
         self, ceiling_176: CeilingLight
@@ -2199,7 +2229,7 @@ class TestCeilingLightTurnOnPowerBehavior:
         """Stored brightness=0 colors are skipped; brightness is inferred instead."""
         # Simulate: device was off, user called turn_uplight_on which stored
         # downlight colors with brightness=0
-        ceiling_176._stored_downlight_state = [
+        ceiling_176.state.stored_downlight_colors = [
             HSBK(hue=60, saturation=0.5, brightness=0.0, kelvin=4000)
         ] * 63
 
@@ -2233,7 +2263,7 @@ class TestCeilingLightTurnOnPowerBehavior:
         """Stored brightness=0 color is skipped; brightness is inferred instead."""
         # Simulate: device was off, user called turn_downlight_on which stored
         # uplight color with brightness=0
-        ceiling_176._stored_uplight_state = HSBK(
+        ceiling_176.state.stored_uplight_color = HSBK(
             hue=60, saturation=0.5, brightness=0.0, kelvin=4000
         )
 

--- a/tests/test_devices/test_ceiling.py
+++ b/tests/test_devices/test_ceiling.py
@@ -1838,6 +1838,51 @@ class TestCeilingLightSetPowerOverride:
         assert ceiling_176.state.stored_uplight_color.hue == 100
         assert ceiling_176.state.stored_downlight_colors[0].hue == 200
 
+    async def test_set_power_on_recomputes_is_on_flags(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test set_power(True) recomputes is_on from last colours."""
+        # Pre-set last-known colours with brightness > 0
+        ceiling_176.state.last_uplight_color = HSBK(
+            hue=100, saturation=0.5, brightness=0.8, kelvin=3500
+        )
+        ceiling_176.state.last_downlight_colors = [
+            HSBK(hue=200, saturation=0.5, brightness=0.6, kelvin=3500)
+        ] * 16
+
+        # Before power-on, mark as off
+        ceiling_176.state.uplight_is_on = False
+        ceiling_176.state.downlight_is_on = False
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.set_power(True)
+
+        # After power-on, flags should be recomputed from last-known colours
+        assert ceiling_176.state.uplight_is_on is True
+        assert ceiling_176.state.downlight_is_on is True
+
+    async def test_set_power_on_recomputes_is_on_flags_zero_brightness(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Test set_power(True) sets is_on=False for zero brightness."""
+        # Pre-set last-known colours with brightness == 0
+        ceiling_176.state.last_uplight_color = HSBK(
+            hue=100, saturation=0.5, brightness=0.0, kelvin=3500
+        )
+        ceiling_176.state.last_downlight_colors = [
+            HSBK(hue=200, saturation=0.5, brightness=0.0, kelvin=3500)
+        ] * 16
+
+        ceiling_176.state.uplight_is_on = False
+        ceiling_176.state.downlight_is_on = False
+
+        with patch.object(MatrixLight, "set_power", new_callable=AsyncMock):
+            await ceiling_176.set_power(True)
+
+        # Zero brightness means components are not considered "on"
+        assert ceiling_176.state.uplight_is_on is False
+        assert ceiling_176.state.downlight_is_on is False
+
     async def test_set_power_with_integer_off(self, ceiling_176: CeilingLight) -> None:
         """Test set_power(0) captures colors (integer form)."""
         uplight_color = HSBK(hue=300, saturation=0.9, brightness=0.6, kelvin=3000)


### PR DESCRIPTION
Move _stored_uplight_state, _stored_downlight_state, _last_uplight_color and _last_downlight_colors from private attributes on CeilingLight to public fields on CeilingLightState, making them accessible to consumers via the state property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved stored and last-known uplight/downlight color tracking into the persisted device state; on/off status, brightness inference, restoration targets, and refresh/control behavior are now deterministic, persisted, and validated against downlight zone configuration.

* **Tests**
  * Expanded tests and helpers to cover the new state model, JSON persistence edge cases, refresh/control interactions, brightness inference, restoration scenarios, and downlight zone validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->