### PR TITLE
fix: set a default value for duration_seconds for set_hev_cycle

### DIFF
--- a/src/lifx/devices/hev.py
+++ b/src/lifx/devices/hev.py
@@ -182,7 +182,7 @@ class HevLight(Light):
 
         return cycle_state
 
-    async def set_hev_cycle(self, enable: bool, duration_seconds: int) -> None:
+    async def set_hev_cycle(self, enable: bool, duration_seconds: int = 0) -> None:
         """Start or stop a HEV cleaning cycle.
 
         If a duration is not provided, the light will use whatever the default

--- a/tests/test_devices/test_hev.py
+++ b/tests/test_devices/test_hev.py
@@ -85,6 +85,19 @@ class TestHevLight:
         assert packet.enable is False
         assert packet.duration_s == 0
 
+    async def test_set_hev_cycle_default_duration(self, hev_light: HevLight) -> None:
+        """Test starting a HEV cycle with default duration (0 = device default)."""
+        hev_light.connection.request.return_value = True
+
+        await hev_light.set_hev_cycle(enable=True)
+
+        call_args = hev_light.connection.request.call_args
+        packet = call_args[0][0]
+
+        assert isinstance(packet, packets.Light.SetHevCycle)
+        assert packet.enable is True
+        assert packet.duration_s == 0
+
     async def test_set_hev_cycle_invalid_duration(self, hev_light: HevLight) -> None:
         """Test setting HEV cycle with invalid duration."""
         with pytest.raises(ValueError, match="Duration must be non-negative"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HEV light cycle operations now accept optional duration parameters, automatically using device defaults when not specified.

* **Tests**
  * Added tests to verify HEV cycle behavior with default duration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->