### PR TITLE
fix: expose raw HSBK values instead of rounded ones

### DIFF
--- a/src/lifx/color.py
+++ b/src/lifx/color.py
@@ -265,21 +265,19 @@ class HSBK:
         self._kelvin = kelvin
 
     def __eq__(self, other: object) -> bool:
-        """Two colors are equal if they have the same HSBK values."""
-        if not isinstance(other, HSBK):  # pragma: no cover
+        """Two colors are equal if they share the same wire representation.
+
+        Equality is defined at uint16 (protocol) granularity rather than on the
+        raw floats. This keeps colors that round-trip through the protocol stable
+        under comparison despite sub-uint16 floating-point drift.
+        """
+        if not isinstance(other, HSBK):
             return NotImplemented
-        return (
-            other.hue == self.hue
-            and other.saturation == self.saturation
-            and other.brightness == self.brightness
-            and other.kelvin == self.kelvin
-        )
+        return self.as_tuple() == other.as_tuple()
 
     def __hash__(self) -> int:
-        """Returns a hash of this color as an integer."""
-        return hash(
-            (self.hue, self.saturation, self.brightness, self.kelvin)
-        )  # pragma: no cover
+        """Return a hash consistent with uint16 equality."""
+        return hash(self.as_tuple())
 
     def __str__(self) -> str:
         """Return a string representation of the HSBK values for this color."""
@@ -299,18 +297,18 @@ class HSBK:
 
     @property
     def hue(self) -> float:
-        """Return hue (rounded to nearest integer degree for display)."""
-        return round(self._hue)
+        """Return the raw hue in degrees (0-360)."""
+        return self._hue
 
     @property
     def saturation(self) -> float:
-        """Return saturation (rounded to 2 decimal places for display)."""
-        return round(self._saturation, 2)
+        """Return the raw saturation (0.0-1.0)."""
+        return self._saturation
 
     @property
     def brightness(self) -> float:
-        """Return brightness (rounded to 2 decimal places for display)."""
-        return round(self._brightness, 2)
+        """Return the raw brightness (0.0-1.0)."""
+        return self._brightness
 
     @property
     def kelvin(self) -> int:
@@ -426,10 +424,11 @@ class HSBK:
             print(f"Hue: {color.hue}°, Brightness: {color.brightness * 100}%")
             ```
         """
-        # Convert from uint16 ranges to user-friendly ranges
-        hue = round(float(protocol.hue) * 360 / 0x10000)
-        saturation = round(float(protocol.saturation) / 0xFFFF, 2)
-        brightness = round(float(protocol.brightness) / 0xFFFF, 2)
+        # Convert from uint16 ranges to user-friendly ranges, preserving the
+        # full precision of the device value (no rounding).
+        hue = float(protocol.hue) * 360 / 0x10000
+        saturation = float(protocol.saturation) / 0xFFFF
+        brightness = float(protocol.brightness) / 0xFFFF
 
         return cls(
             hue=hue,

--- a/src/lifx/color.py
+++ b/src/lifx/color.py
@@ -517,13 +517,13 @@ class HSBK:
             diff -= 360
         elif diff < -180:
             diff += 360
-        hue = round(self._hue + diff * blend) % 360
+        hue = (self._hue + diff * blend) % 360
         sat = self._saturation + (other._saturation - self._saturation) * blend
         bri = self._brightness + (other._brightness - self._brightness) * blend
         return HSBK(
             hue=hue,
-            saturation=round(sat, 2),
-            brightness=round(bri, 2),
+            saturation=sat,
+            brightness=bri,
             kelvin=self._kelvin,
         )
 
@@ -555,9 +555,9 @@ class HSBK:
         r, g, b = _oklab_to_srgb(l_interp, a_interp, ob_interp)
         h, s, v = colorsys.rgb_to_hsv(r, g, b)
         return HSBK(
-            hue=round(h * 360) % 360,
-            saturation=round(s, 2),
-            brightness=round(v, 2),
+            hue=(h * 360) % 360,
+            saturation=s,
+            brightness=v,
             kelvin=self._kelvin,
         )
 
@@ -692,9 +692,8 @@ class HSBK:
         if hue < 0.0:
             hue += 1.0
         hue *= 360
-        hue = round(hue)
-        saturation = round(saturation_total / len(colors), 2)
-        brightness = round(brightness_total / len(colors), 2)
+        saturation = saturation_total / len(colors)
+        brightness = brightness_total / len(colors)
         kelvin = round(kelvin_total / len(colors))
 
         return cls(hue, saturation, brightness, kelvin)

--- a/src/lifx/devices/ceiling.py
+++ b/src/lifx/devices/ceiling.py
@@ -37,6 +37,21 @@ from lifx.products import get_ceiling_layout, is_ceiling_product
 _LOGGER = logging.getLogger(__name__)
 
 
+def _hsk_matches(stored: HSBK, current: HSBK) -> bool:
+    """Compare hue/saturation/kelvin at uint16 (wire) granularity.
+
+    Brightness is intentionally ignored. Comparing the decoded uint16 values
+    rather than the raw floats keeps stored-state validity stable across a
+    protocol round-trip, which exposes slightly different raw H/S/B floats for
+    the same wire representation.
+    """
+    sp = stored.to_protocol()
+    cp = current.to_protocol()
+    return (
+        sp.hue == cp.hue and sp.saturation == cp.saturation and sp.kelvin == cp.kelvin
+    )
+
+
 @dataclass
 class CeilingLightState(MatrixLightState):
     """Ceiling light device state with uplight/downlight component control.
@@ -1205,11 +1220,7 @@ class CeilingLight(MatrixLight):
                 return False
 
             stored = state.stored_uplight_color
-            return (
-                stored.hue == current.hue
-                and stored.saturation == current.saturation
-                and stored.kelvin == current.kelvin
-            )
+            return _hsk_matches(stored, current)
 
         if component == "downlight":
             if state.stored_downlight_colors is None or not isinstance(current, list):
@@ -1218,9 +1229,9 @@ class CeilingLight(MatrixLight):
             if len(state.stored_downlight_colors) != len(current):
                 return False
 
-            # Check if all zones match (H, S, K)
+            # Check if all zones match (H, S, K at wire granularity)
             return all(
-                s.hue == c.hue and s.saturation == c.saturation and s.kelvin == c.kelvin
+                _hsk_matches(s, c)
                 for s, c in zip(state.stored_downlight_colors, current)
             )
 

--- a/src/lifx/devices/matrix.py
+++ b/src/lifx/devices/matrix.py
@@ -810,15 +810,9 @@ class MatrixLight(Light):
                 f"Color count mismatch: expected {tile.total_zones}, got {len(colors)}"
             )
 
-        # Check if all colors are the same
+        # Check if all colors are the same (uint16 wire equality)
         first_color = colors[0]
-        all_same = all(
-            c.hue == first_color.hue
-            and c.saturation == first_color.saturation
-            and c.brightness == first_color.brightness
-            and c.kelvin == first_color.kelvin
-            for c in colors
-        )
+        all_same = all(c == first_color for c in colors)
 
         if all_same:
             # All zones same color - use SetColor packet (much faster!)

--- a/src/lifx/theme/theme.py
+++ b/src/lifx/theme/theme.py
@@ -183,13 +183,7 @@ class Theme:
                 print("Red is in the theme")
             ```
         """
-        return any(
-            c.hue == color.hue
-            and c.saturation == color.saturation
-            and c.brightness == color.brightness
-            and c.kelvin == color.kelvin
-            for c in self.colors
-        )
+        return any(c == color for c in self.colors)
 
     def __repr__(self) -> str:
         """Return a string representation of the theme."""

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -410,6 +410,43 @@ class TestHSBKRawValues:
         # The raw values are explicitly NOT the old rounded forms.
         assert color.saturation != round(12345 / 0xFFFF, 2)
 
+    def test_lerp_hsb_returns_unrounded(self) -> None:
+        """lerp_hsb keeps full precision instead of rounding to 2dp."""
+        start = HSBK(hue=0, saturation=0.0, brightness=0.0, kelvin=3500)
+        end = HSBK(hue=0, saturation=1.0, brightness=1.0, kelvin=3500)
+
+        mid = start.lerp_hsb(end, 1 / 3)
+
+        assert mid.saturation == pytest.approx(1 / 3, abs=1e-6)
+        assert mid.brightness == pytest.approx(1 / 3, abs=1e-6)
+        assert mid.saturation != round(1 / 3, 2)
+
+    def test_lerp_oklab_returns_unrounded(self) -> None:
+        """lerp_oklab keeps full precision instead of rounding to 2dp."""
+        red = HSBK(hue=0, saturation=1.0, brightness=1.0, kelvin=3500)
+        blue = HSBK(hue=240, saturation=1.0, brightness=1.0, kelvin=3500)
+
+        mid = red.lerp_oklab(blue, 0.5)
+
+        # At least one channel carries more than 2 decimal places of precision.
+        assert any(
+            round(v, 2) != v for v in (mid.hue / 360, mid.saturation, mid.brightness)
+        )
+
+    def test_average_returns_unrounded(self) -> None:
+        """average keeps full precision for hue/saturation/brightness."""
+        colors = [
+            HSBK(hue=0, saturation=0.1, brightness=0.1, kelvin=3500),
+            HSBK(hue=0, saturation=0.1, brightness=0.1, kelvin=3500),
+            HSBK(hue=0, saturation=0.2, brightness=0.2, kelvin=3500),
+        ]
+
+        avg = HSBK.average(colors)
+
+        assert avg.saturation == pytest.approx(0.4 / 3, abs=1e-6)
+        assert avg.brightness == pytest.approx(0.4 / 3, abs=1e-6)
+        assert avg.saturation != round(0.4 / 3, 2)
+
 
 class TestHSBKEquality:
     """Equality and hashing are defined at uint16 (wire) granularity."""

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -386,6 +386,68 @@ class TestHSBKThemeMethods:
             HSBK.average([])
 
 
+class TestHSBKRawValues:
+    """The getters and from_protocol expose raw, unrounded values."""
+
+    def test_getters_return_unrounded_values(self) -> None:
+        """Hue, saturation and brightness are returned without rounding."""
+        color = HSBK(hue=180.7, saturation=0.123, brightness=0.456, kelvin=3500)
+
+        # Previously these rounded to 181, 0.12 and 0.46 respectively.
+        assert color.hue == 180.7
+        assert color.saturation == 0.123
+        assert color.brightness == 0.456
+
+    def test_from_protocol_preserves_raw_precision(self) -> None:
+        """from_protocol no longer quantises to integer hue / 2dp sat-bri."""
+        # uint16 values that do not map cleanly to an integer degree or 2dp.
+        protocol = LightHsbk(hue=12345, saturation=12345, brightness=54321, kelvin=4000)
+        color = HSBK.from_protocol(protocol)
+
+        assert color.hue == pytest.approx(12345 * 360 / 0x10000)
+        assert color.saturation == pytest.approx(12345 / 0xFFFF)
+        assert color.brightness == pytest.approx(54321 / 0xFFFF)
+        # The raw values are explicitly NOT the old rounded forms.
+        assert color.saturation != round(12345 / 0xFFFF, 2)
+
+
+class TestHSBKEquality:
+    """Equality and hashing are defined at uint16 (wire) granularity."""
+
+    def test_equal_when_wire_representation_matches(self) -> None:
+        """Colors differing only below uint16 resolution are equal."""
+        color = HSBK(hue=34, saturation=0.75, brightness=0.902, kelvin=3500)
+        roundtrip = HSBK.from_protocol(color.to_protocol())
+
+        # Raw values now differ slightly, but the wire representation matches.
+        assert roundtrip is not color
+        assert roundtrip == color
+        assert hash(roundtrip) == hash(color)
+
+    def test_membership_uses_wire_equality(self) -> None:
+        """A protocol round-tripped color is still found in a set/list."""
+        color = HSBK(hue=39, saturation=0.75, brightness=0.902, kelvin=3500)
+        roundtrip = HSBK.from_protocol(color.to_protocol())
+
+        assert roundtrip in {color}
+        assert roundtrip in [color]
+
+    def test_not_equal_when_wire_representation_differs(self) -> None:
+        """Distinct colors remain unequal."""
+        red = HSBK(hue=0, saturation=1.0, brightness=1.0, kelvin=3500)
+        blue = HSBK(hue=240, saturation=1.0, brightness=1.0, kelvin=3500)
+
+        assert red != blue
+        assert hash(red) != hash(blue)
+
+    def test_eq_returns_not_implemented_for_non_hsbk(self) -> None:
+        """Comparing against a non-HSBK object is not equal, not an error."""
+        color = HSBK(hue=0, saturation=1.0, brightness=1.0, kelvin=3500)
+
+        assert color != "not a color"
+        assert (color == 42) is False
+
+
 class TestHSBKLerpHsb:
     """Tests for HSBK.lerp_hsb shortest-path HSB interpolation."""
 

--- a/tests/test_devices/test_ceiling.py
+++ b/tests/test_devices/test_ceiling.py
@@ -1257,6 +1257,42 @@ class TestCeilingLightIsStoredStateValid:
 
         assert ceiling_176._is_stored_state_valid("unknown", current) is False
 
+    def test_uplight_valid_match_after_roundtrip(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Uplight stays valid when current came back via a protocol round-trip.
+
+        The same wire tuple decodes to slightly different raw H/S floats, so a
+        raw-float comparison would wrongly fail. Wire-granularity comparison
+        keeps it valid (brightness still ignored).
+        """
+        stored = HSBK(hue=34, saturation=0.75, brightness=0.902, kelvin=3500)
+        ceiling_176.state.stored_uplight_color = stored
+        # Same H/S/K read back from the device, with a different brightness.
+        current = HSBK.from_protocol(
+            HSBK(hue=34, saturation=0.75, brightness=0.3, kelvin=3500).to_protocol()
+        )
+
+        # Raw floats genuinely differ after the round-trip.
+        assert current.hue != stored.hue
+        assert ceiling_176._is_stored_state_valid("uplight", current) is True
+
+    def test_downlight_valid_match_after_roundtrip(
+        self, ceiling_176: CeilingLight
+    ) -> None:
+        """Downlight zones stay valid after a protocol round-trip."""
+        stored = HSBK(hue=34, saturation=0.75, brightness=0.902, kelvin=3500)
+        ceiling_176.state.stored_downlight_colors = [stored for _ in range(63)]
+        current = [
+            HSBK.from_protocol(
+                HSBK(hue=34, saturation=0.75, brightness=0.3, kelvin=3500).to_protocol()
+            )
+            for _ in range(63)
+        ]
+
+        assert current[0].saturation != stored.saturation
+        assert ceiling_176._is_stored_state_valid("downlight", current) is True
+
 
 class TestCeilingLightStateFileEdgeCases:
     """Tests for state file edge cases."""

--- a/tests/test_devices/test_matrix.py
+++ b/tests/test_devices/test_matrix.py
@@ -400,7 +400,7 @@ class TestMatrixLight:
 
             # Verify the copy worked
             copied_colors = await matrix.get64()
-            assert copied_colors[0].hue == 240  # Blue
+            assert copied_colors[0].hue == pytest.approx(240, abs=0.01)  # Blue
             assert copied_colors[0].saturation == 1.0
             assert copied_colors[0].brightness == 1.0
 

--- a/tests/test_devices/test_state_light.py
+++ b/tests/test_devices/test_state_light.py
@@ -70,7 +70,9 @@ class TestLightStateManagement:
         assert isinstance(light._state, LightState)
         assert light._state.label == "Test Light"
         assert light._state.power == 65535
-        assert light._state.color.hue == 120.0  # 21845/65535 * 360
+        assert light._state.color.hue == pytest.approx(
+            120.0, abs=0.01
+        )  # 21845/65535 * 360
 
     @pytest.mark.asyncio
     async def test_state_property_after_init_returns_light_state(

--- a/tests/test_devices/test_state_management.py
+++ b/tests/test_devices/test_state_management.py
@@ -305,7 +305,7 @@ class TestStateInitialization:
         assert isinstance(light._state, LightState)
         assert light._state.label == "Kitchen Light"
         assert light._state.power == 65535
-        assert light._state.color.hue == 120.0  # 21845/65535 * 360
+        assert light._state.color.hue == pytest.approx(120.0, abs=0.01)
         assert light._state.host_firmware.version_major == 2
         assert light._state.wifi_firmware.version_minor == 80
         assert light._state.location.label == b"Home"
@@ -416,7 +416,7 @@ class TestRefreshState:
         # Verify volatile fields updated
         assert light._state.power == 65535
         assert light._state.color.kelvin == 4000
-        assert light._state.color.brightness == 0.5  # 32768/65535
+        assert light._state.color.brightness == pytest.approx(0.5, abs=0.001)
 
     @pytest.mark.asyncio
     async def test_refresh_state_updates_timestamp(self, light, mock_product_info):

--- a/tests/test_effects/test_newtons_cradle.py
+++ b/tests/test_effects/test_newtons_cradle.py
@@ -549,12 +549,13 @@ class TestShading:
             assert 0.0 <= color.brightness <= 1.0
             assert 1500 <= color.kelvin <= 9000
 
-    def test_hue_is_int(self) -> None:
-        """Test that hue is always an integer."""
+    def test_hue_is_raw_unrounded(self) -> None:
+        """Test that hue is a raw, unrounded numeric value in range."""
         effect = EffectNewtonsCradle(hue=200, saturation=0.5, brightness=0.8)
         for x in range(-9, 10):
             color = effect._shade(x / 10.0)
-            assert isinstance(color.hue, int)
+            assert isinstance(color.hue, (int, float))
+            assert 0 <= color.hue <= 360
 
     def test_specular_blend_toward_white(self) -> None:
         """Test specular bloom reduces saturation (blends toward white)."""

--- a/tests/test_effects/test_plasma2d.py
+++ b/tests/test_effects/test_plasma2d.py
@@ -221,7 +221,7 @@ class TestPlasma2DGenerateFrame:
         )
         colors = effect.generate_frame(ctx)
         for color in colors:
-            assert isinstance(color.hue, int)
+            assert isinstance(color.hue, (int, float))
             assert 0 <= color.hue <= 360
 
     def test_kelvin_matches_configured(self) -> None:


### PR DESCRIPTION
## Summary

The `HSBK` `hue`/`saturation`/`brightness` properties rounded on read (integer hue, 2dp sat/bri), and `from_protocol()` rounded again at construction. Downstream consumers could therefore never obtain the device's full-precision values — the reported issue. A follow-up commit also removes the same rounding from the computed-colour helpers (`average`, `lerp_hsb`, `lerp_oklab`).

This PR exposes raw values end-to-end:

### Decode + getters
- **Getters** return the raw stored floats (no rounding).
- **`from_protocol()`** decodes uint16 → float without rounding, preserving full device precision.

### Stable equality
- **`__eq__`/`__hash__`** are redefined at **uint16 (wire) granularity** via `as_tuple()`. This keeps colours stable under comparison across protocol round-trips despite sub-uint16 floating-point drift — the original reason the getter rounding existed (commit 2cd452e: *"Restore property rounding to preserve equality semantics"*).
- The matrix all-same-colour fast path (`matrix.py`) and `Theme.__contains__` now route through that equality, so membership/`in` checks remain correct.

### Computed colours (2nd commit)
- `average()`, `lerp_hsb()`, `lerp_oklab()` no longer round their results (kelvin stays integral). These feed the effects layer (~10 effects via `lerp_oklab`) and the theme canvas/generators (`average`), all of which serialise to uint16 — so the old 2dp rounding coarsened smooth gradients/blends far below wire resolution. Safe now that equality is uint16-based.

## Why uint16 equality

Without it, a theme colour like `brightness=0.902` would no longer equal the same colour read back from a device (`0.90` over the wire), breaking `color in theme.colors`. Quantising equality to the wire representation makes round-trips exact while still handing consumers the raw floats.

## Tests

- New `TestHSBKRawValues` / `TestHSBKEquality`: raw getters, raw `from_protocol`, raw `lerp`/`average`, uint16 equality/hashing, set/list membership, non-HSBK comparison branch.
- Device-state tests that asserted exact decoded values now use `pytest.approx`; two effect tests that asserted hue was an `int` (a rounding artefact) now assert numeric + in range.
- Full suite: **2533 passed**. ruff format/lint clean, pyright clean on changed source. Patch coverage clean (the single `color.py:517` miss is a pre-existing `lerp_hsb` branch partial, outside this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)